### PR TITLE
Workflow fix benchmarking ci

### DIFF
--- a/.github/workflows/benchmarking.yaml
+++ b/.github/workflows/benchmarking.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up GCC
         uses: egor-tensin/setup-gcc@v1
         with:
-          version: 11
+          version: 9
           platform: x64
       
       - name: Set Flags
@@ -50,7 +50,7 @@ jobs:
         working-directory: ${{github.workspace}}/build
         # Configure CMake with benchmarking option on
         run: |
-          cmake -DNT_USE_PCH=ON -DNT_ENABLE_BENCHMARKING=ON -DCMAKE_PREFIX_PATH=`python3 -c 'import torch;print(torch.utils.cmake_prefix_path)'` -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} .. 
+          cmake --debug-output -DNT_USE_PCH=ON -DNT_ENABLE_BENCHMARKING=ON -DCMAKE_PREFIX_PATH=`python3 -c 'import torch;print(torch.utils.cmake_prefix_path)'` -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} .. 
           echo :::: Build directory post-CMake:
           ls
           echo 

--- a/.github/workflows/benchmarking.yaml
+++ b/.github/workflows/benchmarking.yaml
@@ -18,9 +18,11 @@ jobs:
   benchmark_pr_branch:        
     name: Continuous Benchmarking PRs with Bencher
     # DO NOT REMOVE: For handling Fork PRs see Pull Requests from Forks
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    # if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    
     permissions:
       pull-requests: write
+      
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/benchmarking.yaml
+++ b/.github/workflows/benchmarking.yaml
@@ -18,7 +18,7 @@ jobs:
   benchmark_pr_branch:        
     name: Continuous Benchmarking PRs with Bencher
     # DO NOT REMOVE: For handling Fork PRs see Pull Requests from Forks
-    # if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     
     permissions:
       pull-requests: write
@@ -27,12 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: bencherdev/bencher@main
-      
-      - name: Set up GCC
-        uses: egor-tensin/setup-gcc@v1
-        with:
-          version: 9
-          platform: x64
       
       - name: Set Flags
         run: export USE_CUDA=0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,8 @@ ENDIF()
 
 find_package(Torch REQUIRED)
 find_package(Protobuf REQUIRED)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
+message("Torch cxx flags: ${TORCH_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "--Wabi-tag ${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
 
 
 ######################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ ENDIF()
 find_package(Torch REQUIRED)
 find_package(Protobuf REQUIRED)
 message("Torch cxx flags: ${TORCH_CXX_FLAGS}")
-set(CMAKE_CXX_FLAGS "--Wabi-tag ${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-Wabi-tag ${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
 
 
 ######################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,11 @@ enable_testing()
 #### add dependencies ####
 ##########################
 
+find_package(Torch REQUIRED)
+find_package(Protobuf REQUIRED)
+message("Torch cxx flags: ${TORCH_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-Wabi-tag ${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
+
 include(cmake/CPM.cmake)
 
 CPMAddPackage("gh:gabime/spdlog@1.8.2")
@@ -43,11 +48,6 @@ OPTION(NT_BUILD_TIMING "output time to build each target" OFF)
 IF(NT_BUILD_TIMING)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_COMMAND} -E time")
 ENDIF()
-
-find_package(Torch REQUIRED)
-find_package(Protobuf REQUIRED)
-message("Torch cxx flags: ${TORCH_CXX_FLAGS}")
-set(CMAKE_CXX_FLAGS "-Wabi-tag ${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
 
 
 ######################################


### PR DESCRIPTION
FINALLY fix issue with nuTens not linking properly with bencher in github action. 

Seems to have been related to the flag glibcxx_use_cxx11_abi which is related to backwards compatibility with c++11 involving strings (see https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html for details) , hence why linking issue was only happening with functions taking std::string as a parameter. The flag was getting set to 0 when libtorch was included, but google benchmark was getting built with it set to 1, causing linking issues. Setting the CMAKE_CXX_FLAGS variable to include the TORCH_CXX_FLAGS *before* oncluding benchmark fixes the issue as benchmark now gets built with the same flags as everything else.

closes #38 