### PR TITLE
Add tests for python interface

### DIFF
--- a/.github/workflows/CI-Python.yaml
+++ b/.github/workflows/CI-Python.yaml
@@ -42,4 +42,5 @@ jobs:
          pip install pytest
          # Need to set the library path so that torch can find itself (:
          export LD_LIBRARY_PATH=`python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`:$LD_LIBRARY_PATH
+         echo LD_LIBRARY_PATH
          pytest tests/python/*.py

--- a/.github/workflows/CI-Python.yaml
+++ b/.github/workflows/CI-Python.yaml
@@ -37,5 +37,7 @@ jobs:
     - name: Build and install
       run: pip install --verbose .
 
-    #- name: Test
-    #  run: pytest
+    - name: Test
+      run: |
+         pip install pytest
+         pytest tests/python/*.py

--- a/.github/workflows/CI-Python.yaml
+++ b/.github/workflows/CI-Python.yaml
@@ -37,9 +37,10 @@ jobs:
     - name: Build and install
       run: pip install --verbose .
 
+    # Need to set the library path so that torch can find itself (:
+    - run: export LD_LIBRARY_PATH=`python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`:$LD_LIBRARY_PATH
+
     - name: Test
       run: |
-         # Need to set the library path so that torch can find itself (:
-         export LD_LIBRARY_PATH=`python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`:$LD_LIBRARY_PATH
          pip install pytest
          pytest tests/python/*.py

--- a/.github/workflows/CI-Python.yaml
+++ b/.github/workflows/CI-Python.yaml
@@ -41,7 +41,7 @@ jobs:
       run: |
          pip install pytest
          # Need to set the library path so that torch can find itself (:
-         export LD_LIBRARY_PATH=`python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`:$LD_LIBRARY_PATH
+         export LD_LIBRARY_PATH=`python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`/lib:$LD_LIBRARY_PATH
          echo $LD_LIBRARY_PATH
          ls `python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`
          pytest tests/python/*.py

--- a/.github/workflows/CI-Python.yaml
+++ b/.github/workflows/CI-Python.yaml
@@ -35,11 +35,10 @@ jobs:
         path: "PyTorch_requirements.txt"
 
     - name: Build and install
-      run: pip install --verbose .
+      run: pip install --verbose .[testing]
 
     - name: Test
       run: |
-         pip install pytest
          # Need to set the library path so that torch can find itself (:
          export LD_LIBRARY_PATH=`python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`/lib:$LD_LIBRARY_PATH
          pytest tests/python/*.py

--- a/.github/workflows/CI-Python.yaml
+++ b/.github/workflows/CI-Python.yaml
@@ -42,6 +42,4 @@ jobs:
          pip install pytest
          # Need to set the library path so that torch can find itself (:
          export LD_LIBRARY_PATH=`python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`/lib:$LD_LIBRARY_PATH
-         echo $LD_LIBRARY_PATH
-         ls `python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`
          pytest tests/python/*.py

--- a/.github/workflows/CI-Python.yaml
+++ b/.github/workflows/CI-Python.yaml
@@ -43,5 +43,5 @@ jobs:
          # Need to set the library path so that torch can find itself (:
          export LD_LIBRARY_PATH=`python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`:$LD_LIBRARY_PATH
          echo $LD_LIBRARY_PATH
-         ls $LD_LIBRARY_PATH
+         ls `python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`:$LD_LIBRARY_PATH
          pytest tests/python/*.py

--- a/.github/workflows/CI-Python.yaml
+++ b/.github/workflows/CI-Python.yaml
@@ -43,5 +43,5 @@ jobs:
          # Need to set the library path so that torch can find itself (:
          export LD_LIBRARY_PATH=`python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`:$LD_LIBRARY_PATH
          echo $LD_LIBRARY_PATH
-         ls `python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`:$LD_LIBRARY_PATH
+         ls `python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`
          pytest tests/python/*.py

--- a/.github/workflows/CI-Python.yaml
+++ b/.github/workflows/CI-Python.yaml
@@ -39,5 +39,7 @@ jobs:
 
     - name: Test
       run: |
+         # Need to set the library path so that torch can find itself (:
+         export LD_LIBRARY_PATH=`python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`:$LD_LIBRARY_PATH
          pip install pytest
          pytest tests/python/*.py

--- a/.github/workflows/CI-Python.yaml
+++ b/.github/workflows/CI-Python.yaml
@@ -42,5 +42,5 @@ jobs:
          pip install pytest
          # Need to set the library path so that torch can find itself (:
          export LD_LIBRARY_PATH=`python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`:$LD_LIBRARY_PATH
-         echo LD_LIBRARY_PATH
+         echo $LD_LIBRARY_PATH
          pytest tests/python/*.py

--- a/.github/workflows/CI-Python.yaml
+++ b/.github/workflows/CI-Python.yaml
@@ -37,10 +37,9 @@ jobs:
     - name: Build and install
       run: pip install --verbose .
 
-    # Need to set the library path so that torch can find itself (:
-    - run: export LD_LIBRARY_PATH=`python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`:$LD_LIBRARY_PATH
-
     - name: Test
       run: |
          pip install pytest
+         # Need to set the library path so that torch can find itself (:
+         export LD_LIBRARY_PATH=`python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`:$LD_LIBRARY_PATH
          pytest tests/python/*.py

--- a/.github/workflows/CI-Python.yaml
+++ b/.github/workflows/CI-Python.yaml
@@ -43,4 +43,5 @@ jobs:
          # Need to set the library path so that torch can find itself (:
          export LD_LIBRARY_PATH=`python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`:$LD_LIBRARY_PATH
          echo $LD_LIBRARY_PATH
+         ls $LD_LIBRARY_PATH
          pytest tests/python/*.py

--- a/PyTorch_requirements.txt
+++ b/PyTorch_requirements.txt
@@ -12,6 +12,7 @@ referencing==0.35.1
 rpds-py==0.10.0
 six==1.16.0
 sympy==1.12.1
+numpy
 
 --find-links https://download.pytorch.org/whl/torch_stable.html
 torch==2.0.1+cpu

--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ cmake -DNT_ENABLE_PYTHON=ON <other options> <source dir>
 ```
 and doing `make && make install`
 
+### Known Issues
+
+When trying to run using the python interface you may get complaints relating to not being able to locate `libtorch.so` or `libtorch_cpu.so` library files. If so running
+
+```
+export LD_LIBRARY_PATH=`python3 -c 'import os;import torch;print(os.path.abspath(torch.__file__)[:-11])'`/lib:$LD_LIBRARY_PATH
+```
+
+should allow these files to be found
+
 
 
 ## Benchmarking

--- a/examples/python/barger-propagator.py
+++ b/examples/python/barger-propagator.py
@@ -1,0 +1,114 @@
+"""Example script using simple Barger propagator for two flavour neutrino oscillations
+
+This will give you an example of how to use the  the Barger propagator 
+implemented in the testing library of nuTens, which you should use to 
+implement your own tests of any fancy new propagators you implement.
+
+Will produce four plots:
+  
+    - two-flavour-vacuum-oscillation-barger-probs.png
+    - two-flavour-matter-oscillation-barger-probs.png
+
+    These can be compared against figure 2 in 
+    [Vernon D. Barger, K. Whisnant, S. Pakvasa, and R. J. N. Phillips. Matter Effects on Three-Neutrino Oscillations. Phys. Rev. D, 22:2718, 1980.]
+    to check that the propagator is working as expected, 
+    and also as a useful reference to compare against.
+
+    - two-flavour-vacuum-oscillation-barger-probs-LoverE.png
+    - two-flavour-matter-oscillation-barger-probs-LoverE.png
+
+    These are more standart L/E plots.
+
+"""
+
+import nuTens as nt
+from nuTens.testing import TwoFlavourBarger
+import matplotlib.pyplot as plt
+import numpy as np
+import typing
+
+
+## oscillation parameters, taken from Barger paper
+baseline = 5e6 * nt.units.m 
+density  = 0.5 # g/N_a/cm^3 * N_a/N_e
+mass_diff = 1.0 * nt.units.eV 
+alpha = 0.3927 # 22.5 degrees
+
+energies = np.logspace(start=4.0, stop=8.0, num=1000, endpoint=True, base=10.0) * nt.units.MeV
+energy_list = [e for e in energies]
+
+## "classical" Barger propagator
+vacuum_barger = TwoFlavourBarger()
+barger = TwoFlavourBarger()
+vacuum_barger.set_params(0.0, mass_diff, alpha, baseline, 0)
+barger.set_params(0.0, mass_diff, alpha, baseline, density)
+
+
+#########################################################################
+### Make plots as fn of E / dm^2 to compare with fig2 in Barger et al ###
+#########################################################################
+
+plt.clf()
+plt.plot((energies / nt.units.MeV) / (mass_diff * mass_diff), [vacuum_barger.calculate_prob(e, i=0, j=0) for e in energy_list], label = "nu_a -> nu_a")
+plt.plot((energies / nt.units.MeV) / (mass_diff * mass_diff), [vacuum_barger.calculate_prob(e, i=0, j=1) for e in energy_list], label = "nu_a -> nu_b")
+plt.plot((energies / nt.units.MeV) / (mass_diff * mass_diff), [vacuum_barger.calculate_prob(e, i=0, j=0) + vacuum_barger.calculate_prob(e, i=0, j=1) for e in energy_list], label = "Total")
+plt.xlabel("E / dm^2 [MeV / eV^2]")
+plt.ylabel("Oscillation probability")
+plt.title("Vacuum Oscillations")
+plt.legend()
+plt.semilogx()
+plt.show()
+plt.savefig("two-flavour-vacuum-oscillation-barger-probs.png")
+
+plt.clf()
+plt.plot((energies / nt.units.MeV) / (mass_diff * mass_diff), [barger.calculate_prob(e, i=0, j=0) for e in energy_list], label = "nu_a -> nu_a")
+plt.plot((energies / nt.units.MeV) / (mass_diff * mass_diff), [barger.calculate_prob(e, i=0, j=1) for e in energy_list], label = "nu_a -> nu_b")
+plt.plot((energies / nt.units.MeV) / (mass_diff * mass_diff), [barger.calculate_prob(e, i=0, j=0) + barger.calculate_prob(e, i=0, j=1) for e in energy_list], label = "Total")
+plt.xlabel("E / dm^2 [MeV / eV^2]")
+plt.ylabel("Oscillation probability")
+plt.title("Matter Oscillations")
+plt.legend()
+plt.semilogx()
+plt.show()
+plt.savefig("two-flavour-matter-oscillation-barger-probs.png")
+
+
+
+
+###############################
+### Make plots as fn of L/E ###
+###############################
+
+# change up the parameters
+baseline = 10.0 * nt.units.km # value not super important since we are plotting L/E
+density  = 0.5 # g/N_a/cm^3 * N_a/N_e
+mass_diff = 0.04816637831 * nt.units.eV 
+alpha = 0.59437
+
+energies = np.logspace(start=-4.0, stop=2.0, num=1000, endpoint=True, base=10.0) * nt.units.GeV
+energy_list = [e for e in energies]
+
+vacuum_barger.set_params(m1=0.0, m2=mass_diff, theta=alpha, baseline=baseline, density=0.0)
+barger.set_params(0.0, mass_diff, alpha, baseline, density)
+
+plt.clf()
+plt.plot( ( baseline / nt.units.km) / (energies / nt.units.GeV), [vacuum_barger.calculate_prob(e, i=0, j=0) for e in energy_list], label = "nu_a -> nu_a")
+plt.plot( ( baseline / nt.units.km) / (energies / nt.units.GeV), [vacuum_barger.calculate_prob(e, i=0, j=1) for e in energy_list], label = "nu_b -> nu_b")
+plt.plot( ( baseline / nt.units.km) / (energies / nt.units.GeV), [vacuum_barger.calculate_prob(e, i=0, j=0) + vacuum_barger.calculate_prob(e, i=0, j=1) for e in energy_list], label = "Total")
+plt.xlabel("L / E [km / GeV]")
+plt.ylabel("Oscillation probability")
+plt.legend()
+plt.xlim((0,4000))
+plt.show()
+plt.savefig("two-flavour-vacuum-oscillation-barger-probs-LoverE.png")
+
+plt.clf()
+plt.plot( ( baseline / nt.units.km) / (energies / nt.units.GeV), [barger.calculate_prob(e, i=0, j=0) for e in energy_list], label = "nu_a -> nu_a")
+plt.plot( ( baseline / nt.units.km) / (energies / nt.units.GeV), [barger.calculate_prob(e, i=0, j=1) for e in energy_list], label = "nu_a -> nu_b")
+plt.plot( ( baseline / nt.units.km) / (energies / nt.units.GeV), [barger.calculate_prob(e, i=0, j=0) + barger.calculate_prob(e, i=0, j=1) for e in energy_list], label = "Total")
+plt.xlabel("L / E [km / GeV]")
+plt.ylabel("Oscillation probability")
+plt.legend()
+plt.xlim((0,4000))
+plt.show()
+plt.savefig("two-flavour-matter-oscillation-barger-probs-LoverE.png")

--- a/examples/python/three-flavour-vacuum.py
+++ b/examples/python/three-flavour-vacuum.py
@@ -63,8 +63,8 @@ PMNS = build_PMNS(theta12, theta13, theta23, deltaCP)
 masses = nt.tensor.zeros([1,3], nt.dtype.scalar_type.float, nt.dtype.device_type.cpu, True)
 
 masses.set_value([0,0], 0.0)
-masses.set_value([0,1], 0.00868)
-masses.set_value([0,2], 0.0501)
+masses.set_value([0,1], 0.00868e-3)
+masses.set_value([0,2], 0.0501e-3)
 
 ## print info about the parameters
 print("PMNS: ")
@@ -75,12 +75,10 @@ print(masses.to_string())
 print()
 
 ## set up the propagator object
-propagator = nt.propagator.Propagator(3, 295000.0)
-matter_solver = nt.propagator.ConstDensitySolver(3, 2.79)
+propagator = nt.propagator.Propagator(3, 23.79e12)#295000.0)
 
 propagator.set_PMNS(PMNS)
 propagator.set_masses(masses)
-#propagator.set_matter_solver(matter_solver)
 
 ## run!
 propagator.set_energies(energies)

--- a/examples/python/three-flavour-vacuum.py
+++ b/examples/python/three-flavour-vacuum.py
@@ -1,4 +1,3 @@
-import torch
 import nuTens as nt
 from nuTens import tensor
 from nuTens.tensor import Tensor
@@ -76,9 +75,13 @@ print()
 
 ## set up the propagator object
 propagator = nt.propagator.Propagator(3, 295.0 * nt.units.km)
+matter_solver = nt.propagator.ConstDensitySolver(3, 2.79)
 
 propagator.set_PMNS(PMNS)
 propagator.set_masses(masses)
+
+## uncomment for matter oscillations
+#propagator.set_matter_solver(matter_solver)
 
 ## run!
 propagator.set_energies(energies)
@@ -144,5 +147,5 @@ axs[1].set_xlabel("Energy [GeV]")
 axs[0].legend()
 axs[1].legend()
 fig.suptitle("Three flavour oscillation probabilities")
-fig.supxlabel("Oscillation probability")
+fig.supylabel("Oscillation probability")
 fig.savefig("oscillation_probs.png")

--- a/examples/python/three-flavour-vacuum.py
+++ b/examples/python/three-flavour-vacuum.py
@@ -46,7 +46,7 @@ def build_PMNS(theta12: Tensor, theta13: Tensor, theta23: Tensor, deltaCP: Tenso
 energies = nt.tensor.ones([N_ENERGIES, 1], nt.dtype.scalar_type.complex_float, nt.dtype.device_type.cpu, False)
 
 for i in range(N_ENERGIES):
-    energies.set_value([i,0], 1.0 + i*0.2)
+    energies.set_value([i,0], (1.0e-6 + i*0.2e-3) * nt.units.GeV)
 
 energies.requires_grad(True)
 
@@ -63,8 +63,8 @@ PMNS = build_PMNS(theta12, theta13, theta23, deltaCP)
 masses = nt.tensor.zeros([1,3], nt.dtype.scalar_type.float, nt.dtype.device_type.cpu, True)
 
 masses.set_value([0,0], 0.0)
-masses.set_value([0,1], 0.00868e-3)
-masses.set_value([0,2], 0.0501e-3)
+masses.set_value([0,1], 0.00868 * nt.units.eV)
+masses.set_value([0,2], 0.0501 * nt.units.eV)
 
 ## print info about the parameters
 print("PMNS: ")
@@ -75,7 +75,7 @@ print(masses.to_string())
 print()
 
 ## set up the propagator object
-propagator = nt.propagator.Propagator(3, 23.79e12)#295000.0)
+propagator = nt.propagator.Propagator(3, 295.0 * nt.units.km)
 
 propagator.set_PMNS(PMNS)
 propagator.set_masses(masses)
@@ -124,22 +124,25 @@ for i in range(N_ENERGIES):
         probabilities.get_value([i, 1, 2])
     )
 
-plt.plot(energy_list, e_survival_prob_list, label = "electron")
-plt.plot(energy_list, mu_survival_prob_list, label = "muon")
-plt.plot(energy_list, tau_survival_prob_list, label = "tau")
-plt.xlabel("Energy [MeV]")
+plt.plot([ e / nt.units.GeV for e in energy_list], e_survival_prob_list, label = "electron")
+plt.plot([ e / nt.units.GeV for e in energy_list], mu_survival_prob_list, label = "muon")
+plt.plot([ e / nt.units.GeV for e in energy_list], tau_survival_prob_list, label = "tau")
+plt.xlabel("Energy [GeV]")
 plt.ylabel("Survival probability")
 plt.legend()
 plt.show()
 plt.savefig("survival_probs.png")
 
 plt.clf()
-plt.plot(energy_list, mu_to_e_prob_list, label = "numu -> nue")
-plt.plot(energy_list, mu_to_tau_prob_list, label = "numu -> nutau")
-plt.plot(energy_list, mu_survival_prob_list, label = "numu -> numu")
-plt.plot(energy_list, mu_total_prob_list, label = "Total")
-plt.xlabel("Energy [MeV]")
-plt.ylabel("Oscillation probability")
-plt.legend()
-plt.show()
-plt.savefig("oscillation_probs.png")
+fig, axs = plt.subplots(2, 1, sharex=True)
+axs[1].plot([ e / nt.units.GeV for e in energy_list], mu_to_e_prob_list, label = "numu -> nue")
+axs[1].set_ylim((0.0, 0.1))
+axs[0].plot([ e / nt.units.GeV for e in energy_list], mu_to_tau_prob_list, label = "numu -> nutau")
+axs[0].plot([ e / nt.units.GeV for e in energy_list], mu_survival_prob_list, label = "numu -> numu")
+axs[0].plot([ e / nt.units.GeV for e in energy_list], mu_total_prob_list, label = "Total")
+axs[1].set_xlabel("Energy [GeV]")
+axs[0].legend()
+axs[1].legend()
+fig.suptitle("Three flavour oscillation probabilities")
+fig.supxlabel("Oscillation probability")
+fig.savefig("oscillation_probs.png")

--- a/examples/python/two-flavour-const-matter.py
+++ b/examples/python/two-flavour-const-matter.py
@@ -4,7 +4,7 @@ from nuTens.tensor import Tensor
 import matplotlib.pyplot as plt
 import typing
 
-N_ENERGIES = 1000
+N_ENERGIES = 10000
 
 def build_PMNS(theta12: Tensor):
     """ Construct a PMNS matrix in the usual parameterisation """
@@ -22,12 +22,12 @@ def build_PMNS(theta12: Tensor):
 energies = nt.tensor.ones([N_ENERGIES, 1], nt.dtype.scalar_type.complex_float, nt.dtype.device_type.cpu, False)
 
 for i in range(N_ENERGIES):
-    energies.set_value([i,0], 1.0 + i*0.2)
+    energies.set_value([i,0], ( 1.0e-6 + i*0.2e-3 ) * nt.units.GeV)
 
 energies.requires_grad(True)
 
 ## define tensors with oscillation parameters
-theta12 = Tensor([0.58], nt.dtype.scalar_type.complex_float, nt.dtype.device_type.cpu, True)
+theta12 = Tensor([0.15], nt.dtype.scalar_type.complex_float, nt.dtype.device_type.cpu, True)
 
 ## make the matrix
 PMNS = build_PMNS(theta12)
@@ -35,8 +35,8 @@ PMNS = build_PMNS(theta12)
 ## set the mass tensor
 masses = nt.tensor.zeros([1,2], nt.dtype.scalar_type.float, nt.dtype.device_type.cpu, True)
 
-masses.set_value([0,0], 0.0)
-masses.set_value([0,1], 0.00868e-3)
+masses.set_value([0,0], 0.00868 * nt.units.eV)
+masses.set_value([0,1], 0.0501 * nt.units.eV)
 
 ## print info about the parameters
 print("PMNS: ")
@@ -47,7 +47,7 @@ print(masses.to_string())
 print()
 
 ## set up the propagator object
-propagator = nt.propagator.Propagator(2, 10) #23.79e12)#295000.0)
+propagator = nt.propagator.Propagator(2, 295 * nt.units.km)
 matter_solver = nt.propagator.ConstDensitySolver(2, 2.79)
 
 propagator.set_PMNS(PMNS)
@@ -94,19 +94,17 @@ for i in range(N_ENERGIES):
         probabilities.get_value([i, 1, 1]) 
     )
 
-plt.plot(energy_list, e_survival_prob_list, label = "electron")
-plt.plot(energy_list, mu_survival_prob_list, label = "muon")
-plt.xlabel("Energy [MeV]")
+plt.plot([ e / nt.units.GeV for e in energy_list ], e_survival_prob_list, label = "a -> a")
+plt.plot([ e / nt.units.GeV for e in energy_list ], mu_survival_prob_list, label = "b -> b")
+plt.xlabel("Energy [GeV]")
 plt.ylabel("Survival probability")
 plt.legend()
 plt.show()
 plt.savefig("two-flavour-matter-survival-probs.png")
 
 plt.clf()
-plt.plot(energy_list, mu_to_e_prob_list, label = "numu -> nue")
-plt.plot(energy_list, mu_survival_prob_list, label = "numu -> numu")
-plt.plot(energy_list, mu_total_prob_list, label = "Total")
-plt.xlabel("Energy [MeV]")
+plt.plot([ e / nt.units.GeV for e in energy_list ], mu_to_e_prob_list, label = "b -> a")
+plt.xlabel("Energy [GeV]")
 plt.ylabel("Oscillation probability")
 plt.legend()
 plt.show()

--- a/examples/python/two-flavour-const-matter.py
+++ b/examples/python/two-flavour-const-matter.py
@@ -1,0 +1,113 @@
+import nuTens as nt
+from nuTens import tensor
+from nuTens.tensor import Tensor
+import matplotlib.pyplot as plt
+import typing
+
+N_ENERGIES = 1000
+
+def build_PMNS(theta12: Tensor):
+    """ Construct a PMNS matrix in the usual parameterisation """
+    # set up the three matrices to build the PMNS matrix
+    PMNS = nt.tensor.zeros([1, 2, 2], nt.dtype.scalar_type.complex_float, nt.dtype.device_type.cpu, True)
+
+    PMNS.set_value([0, 0, 0], tensor.cos(theta12))
+    PMNS.set_value([0, 0, 1], tensor.sin(theta12))
+    PMNS.set_value([0, 1, 0], -tensor.sin(theta12))
+    PMNS.set_value([0, 1, 1], tensor.cos(theta12))
+
+    return PMNS
+
+## First we build up a tensor to contain the test energies
+energies = nt.tensor.ones([N_ENERGIES, 1], nt.dtype.scalar_type.complex_float, nt.dtype.device_type.cpu, False)
+
+for i in range(N_ENERGIES):
+    energies.set_value([i,0], 1.0 + i*0.2)
+
+energies.requires_grad(True)
+
+## define tensors with oscillation parameters
+theta12 = Tensor([0.58], nt.dtype.scalar_type.complex_float, nt.dtype.device_type.cpu, True)
+
+## make the matrix
+PMNS = build_PMNS(theta12)
+
+## set the mass tensor
+masses = nt.tensor.zeros([1,2], nt.dtype.scalar_type.float, nt.dtype.device_type.cpu, True)
+
+masses.set_value([0,0], 0.0)
+masses.set_value([0,1], 0.00868e-3)
+
+## print info about the parameters
+print("PMNS: ")
+print(PMNS.to_string())
+
+print("\nMasses: ")
+print(masses.to_string())
+print()
+
+## set up the propagator object
+propagator = nt.propagator.Propagator(2, 10) #23.79e12)#295000.0)
+matter_solver = nt.propagator.ConstDensitySolver(2, 2.79)
+
+propagator.set_PMNS(PMNS)
+propagator.set_masses(masses)
+propagator.set_matter_solver(matter_solver)
+
+## run!
+propagator.set_energies(energies)
+probabilities = propagator.calculate_probabilities()
+
+## print out some test values
+prob_sum = tensor.scale(tensor.sum(probabilities, [0]), 1.0 / float(N_ENERGIES))
+print("energy integrated probabilities: ")
+print(prob_sum.to_string())
+
+## check that the autograd functionality works
+mu_survival_prob = prob_sum.get_values([1,1])
+print("mu survival prob:")
+print(mu_survival_prob.to_string())
+
+mu_survival_prob.backward()
+print("theta_12 grad: ")
+print(theta12.grad().to_string())
+
+## make plots of the oscillation probabilities
+energy_list = []
+e_survival_prob_list = []
+mu_survival_prob_list = []
+tau_survival_prob_list = []
+
+mu_to_e_prob_list = []
+mu_to_tau_prob_list = []
+mu_total_prob_list = []
+
+for i in range(N_ENERGIES):
+    energy_list.append(energies.get_value([i, 0]))
+    e_survival_prob_list.append(probabilities.get_value([i, 0, 0]))
+    mu_survival_prob_list.append(probabilities.get_value([i, 1, 1]))
+    
+    mu_to_e_prob_list.append(probabilities.get_value([i, 1, 0]))
+    
+    mu_total_prob_list.append(
+        probabilities.get_value([i, 1, 0]) +
+        probabilities.get_value([i, 1, 1]) 
+    )
+
+plt.plot(energy_list, e_survival_prob_list, label = "electron")
+plt.plot(energy_list, mu_survival_prob_list, label = "muon")
+plt.xlabel("Energy [MeV]")
+plt.ylabel("Survival probability")
+plt.legend()
+plt.show()
+plt.savefig("two-flavour-matter-survival-probs.png")
+
+plt.clf()
+plt.plot(energy_list, mu_to_e_prob_list, label = "numu -> nue")
+plt.plot(energy_list, mu_survival_prob_list, label = "numu -> numu")
+plt.plot(energy_list, mu_total_prob_list, label = "Total")
+plt.xlabel("Energy [MeV]")
+plt.ylabel("Oscillation probability")
+plt.legend()
+plt.show()
+plt.savefig("two-flavour-matter-oscillation-probs.png")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ docs = [
   "autodoc",
   "sphinx-rtd-theme",
 ]
+testing = [
+  "pytest"
+]
 
 [project.urls]
 Repository = "https://github.com/ewanwm/nuTens"

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -7,7 +7,7 @@ pybind11_add_module(
 if(NT_USE_PCH)
     target_precompile_headers( _pyNuTens REUSE_FROM nuTens-pch )
 endif()
-target_link_libraries( _pyNuTens PUBLIC nuTens )
+target_link_libraries( _pyNuTens PUBLIC nuTens test-utils )
 
 # This is passing in the version as a define just as an example
 target_compile_definitions( _pyNuTens PRIVATE VERSION_INFO=${CMAKE_PROJECT_VERSION} )

--- a/python/binding.cpp
+++ b/python/binding.cpp
@@ -12,6 +12,7 @@
 #include <nuTens/propagator/units.hpp>
 #include <nuTens/tensors/dtypes.hpp>
 #include <nuTens/tensors/tensor.hpp>
+#include <tests/barger-propagator.hpp>
 
 namespace py = pybind11;
 
@@ -19,6 +20,7 @@ void initTensor(py::module & /*m*/);
 void initPropagator(py::module & /*m*/);
 void initDtypes(py::module & /*m*/);
 void initUnits(py::module & /*m*/);
+void initTesting(py::module & /*m*/);
 
 // initialise the top level module "_pyNuTens"
 // NOLINTNEXTLINE
@@ -29,11 +31,12 @@ PYBIND11_MODULE(_pyNuTens, m)
     initPropagator(m);
     initDtypes(m);
     initUnits(m);
+    initTesting(m);
 
 #ifdef VERSION_INFO
-    m.attr("__version__") = Py_STRINGIFY(VERSION_INFO);
+     m.attr("__version__") = Py_STRINGIFY(VERSION_INFO);
 #else
-    m.attr("__version__") = "dev";
+     m.attr("__version__") = "dev";
 #endif
 }
 
@@ -125,7 +128,7 @@ void initTensor(py::module &m)
 
 void initPropagator(py::module &m)
 {
-    auto m_propagator = m.def_submodule("propagator");
+     auto m_propagator = m.def_submodule("propagator");
 
     py::class_<Propagator>(m_propagator, "Propagator")
         .def(py::init<int, float>())
@@ -154,9 +157,9 @@ void initPropagator(py::module &m)
             "calculate the eigenvalues of the Hamiltonian")
         ;
 
-    py::class_<ConstDensityMatterSolver, std::shared_ptr<ConstDensityMatterSolver>, BaseMatterSolver>(
-        m_propagator, "ConstDensitySolver")
-        .def(py::init<int, float>());
+     py::class_<ConstDensityMatterSolver, std::shared_ptr<ConstDensityMatterSolver>, BaseMatterSolver>(
+          m_propagator, "ConstDensitySolver")
+          .def(py::init<int, float>());
 }
 
 void initDtypes(py::module &m)
@@ -169,14 +172,12 @@ void initDtypes(py::module &m)
         .value("double", NTdtypes::scalarType::kDouble)
         .value("complex_float", NTdtypes::scalarType::kComplexFloat)
         .value("complex_double", NTdtypes::scalarType::kComplexDouble)
-
-        ;
+    ;
 
     py::enum_<NTdtypes::deviceType>(m_dtypes, "device_type")
         .value("cpu", NTdtypes::deviceType::kCPU)
         .value("gpu", NTdtypes::deviceType::kGPU)
-
-        ;
+    ;
 }
 
 void initUnits(py::module &m)
@@ -190,5 +191,33 @@ void initUnits(py::module &m)
     m_units.attr("cm") = py::float_(Units::cm);
     m_units.attr("m")  = py::float_(Units::m);
     m_units.attr("km") = py::float_(Units::km);
+    
+}
 
+void initTesting(py::module &m)
+{
+    auto m_testing = m.def_submodule("testing");
+
+    py::class_<Testing::TwoFlavourBarger>(m_testing, "TwoFlavourBarger")
+        .def(py::init<>())
+        .def("set_params", &Testing::TwoFlavourBarger::setParams, 
+            py::arg("m1"), py::arg("m2"), py::arg("theta"), py::arg("baseline"), py::arg("density") = (float)-999.9
+        )
+        .def("calculate_effective_angle", &Testing::TwoFlavourBarger::calculateEffectiveAngle,
+            py::arg("energy"),
+            "Calculates the effective mixing angle, alpha, in matter"
+        )
+        .def("calculate_effective_dm2", &Testing::TwoFlavourBarger::calculateEffectiveDm2,
+            "Calculates the effective delta m^2 in matter",
+            py::arg("energy")
+        )
+        .def("get_PMNS_element", &Testing::TwoFlavourBarger::getPMNSelement,
+            "Calculates the effective i,j-th element of the mizing matrix for a given energy",
+            py::arg("energy"), py::arg("i"), py::arg("j")
+        )
+        .def("calculate_prob", &Testing::TwoFlavourBarger::calculateProb,
+            "Calculate probability of transitioning from state i to state j for a given energy",
+            py::arg("energy"), py::arg("i"), py::arg("j")
+        )
+    ;
 }

--- a/python/binding.cpp
+++ b/python/binding.cpp
@@ -203,9 +203,16 @@ void initTesting(py::module &m)
         .def("set_params", &Testing::TwoFlavourBarger::setParams, 
             py::arg("m1"), py::arg("m2"), py::arg("theta"), py::arg("baseline"), py::arg("density") = (float)-999.9
         )
+        .def("lv", &Testing::TwoFlavourBarger::lv,
+            "Calculates the vacuum oscillation length",
+            py::arg("energy")
+        )
+        .def("lm", &Testing::TwoFlavourBarger::lm,
+            "Calculates the matter oscillation length"
+        )
         .def("calculate_effective_angle", &Testing::TwoFlavourBarger::calculateEffectiveAngle,
-            py::arg("energy"),
-            "Calculates the effective mixing angle, alpha, in matter"
+            "Calculates the effective mixing angle, alpha, in matter",
+            py::arg("energy")
         )
         .def("calculate_effective_dm2", &Testing::TwoFlavourBarger::calculateEffectiveDm2,
             "Calculates the effective delta m^2 in matter",

--- a/python/nuTens/__init__.py
+++ b/python/nuTens/__init__.py
@@ -1,3 +1,3 @@
-from ._pyNuTens import __doc__, __version__, tensor, propagator, units, dtype
+from ._pyNuTens import __doc__, __version__, tensor, propagator, units, testing, dtype
 
-__all__ = ["__doc__", "__version__", "tensor", "propagator", "units", "dtype"]
+__all__ = ["__doc__", "__version__", "tensor", "propagator", "units", "dtype", "testing"]

--- a/python/nuTens/testing.py
+++ b/python/nuTens/testing.py
@@ -1,0 +1,2 @@
+from ._pyNuTens import testing
+from ._pyNuTens.testing import *

--- a/tests/python/two-flavour-barger.py
+++ b/tests/python/two-flavour-barger.py
@@ -1,0 +1,126 @@
+import unittest
+import math as m
+import numpy as np
+import nuTens as nt
+from nuTens.testing import TwoFlavourBarger
+
+class TestTwoFlavourConstMatter(unittest.TestCase):
+
+    def test_vacuum_zero_theta_barger(self):
+        """ Test that we get no oscillations when theta == 0 for a range of energies
+        """
+
+        baseline = 500.0 * nt.units.km
+        barger = TwoFlavourBarger()
+
+        barger.set_params(m1=0.0, m2=0.005, theta=0.0, baseline=baseline)
+        energies = np.logspace(0.0, 2.0, 100 ) * nt.units.GeV
+
+        for energy in energies:
+        
+            self.assertEqual(barger.calculate_prob(energy, 0, 0), 1.0,
+                            f"a->a prob with theta == 0 is not 1 with E = {energy}")
+            self.assertEqual(barger.calculate_prob(energy, 0, 1), 0.0,
+                            f"a->b prob with theta == 0 is not 0 with E = {energy}")
+            self.assertEqual(barger.calculate_prob(energy, 1, 1), 1.0,
+                            f"b->b prob with theta == 0 is not 1 with E = {energy}")
+            self.assertEqual(barger.calculate_prob(energy, 1, 0), 0.0,
+                            f"b->a prob with theta == 0 is not 0 with E = {energy}")
+            
+    def test_vacuum_zero_dm2_barger(self):
+        """ Test vacuum propagations for some fixed param values
+        """
+
+        baseline = 500.0 * nt.units.km
+        barger = TwoFlavourBarger()
+
+        # check that we get no vacuum oscillations when theta == 0 for a range of
+        # energies
+        barger.set_params(m1=0.01, m2=0.01, theta=m.pi/2.0, baseline=baseline)
+        energies = np.logspace(0.0, 2.0, 100 ) * nt.units.GeV
+
+        for energy in energies:
+        
+            self.assertEqual(barger.calculate_prob(energy, 0, 0), 1.0,
+                            f"a->a prob with dm^2 == 0 is not 1 with E = {energy}")
+            self.assertEqual(barger.calculate_prob(energy, 0, 1), 0.0,
+                            f"a->b prob with dm^2 == 0 is not 0 with E = {energy}")
+            self.assertEqual(barger.calculate_prob(energy, 1, 1), 1.0,
+                            f"b->b prob with dm^2 == 0 is not 1 with E = {energy}")
+            self.assertEqual(barger.calculate_prob(energy, 1, 0), 0.0,
+                            f"b->a prob with dm^2 == 0 is not 0 with E = {energy}")
+        
+class TestVacuumOscProbs(unittest.TestCase):
+    """ check vacuum oscillation probs for some fixed parameters values against externally calculated probs
+    """
+
+    # theta = pi/8, m1 = 1, m2 = 2, E = 3, L = 4
+    # => prob_(alpha != beta) = sin^2(Pi/4) * sin^2(1) = 0.35403670913
+    #    prob_(alpha == beta) =      1 - 0.35403670913 = 0.64596329086
+
+    barger = TwoFlavourBarger()
+    energy = 3.0
+
+    barger.set_params(m1=1.0, m2=2.0, theta=m.pi / 8.0, baseline=4.0)
+
+    def test_survuval(self):
+        self.assertAlmostEqual(self.barger.calculate_prob(self.energy, 0, 0), 0.64596329086, 6,
+                        f"a->a vacuum prob not as expected")
+        self.assertAlmostEqual(self.barger.calculate_prob(self.energy, 1, 1), 0.64596329086, 6,
+                        f"b->b vacuum prob not as expected")
+        
+    def test_oscillation(self):
+        self.assertAlmostEqual(self.barger.calculate_prob(self.energy, 0, 1), 0.35403670913, 6,
+                        f"a->b vacuum prob not as expected")
+        self.assertAlmostEqual(self.barger.calculate_prob(self.energy, 1, 0), 0.35403670913, 6,
+                        f"b->a vacuum prob not as expected")
+        
+ 
+class TestVacuumOscProbs(unittest.TestCase):
+    """test matter propagations for some fixed param values 
+    """
+
+    # theta = 0.24, m1 = 0.04eV, m2 = 0.001eV, E = 1GeV, L = 500km, density = 2
+    # lv = 4pi * E / dm^2 = 7.8588934e+12 
+    # lm = 2pi / ( sqrt(2) * G * density ) = 2.0588727e+13 
+    # gamma = atan( sin( 2theta ) / (cos( 2theta ) - lv / lm) ) / 2.0
+    #       = atan(0.91389598537 ) / 2 = 0.370219805 rad
+    # dM2 = dm^2 * sqrt( 1 - 2 * (lv / lm) * cos(2theta) + (lv / lm)^2)
+    #     = 0.00109453
+    #
+    # => prob_(alpha != beta) = sin^2(2*gamma) * sin^2((L / E) * dM2/4 )
+    #                         = 0.186410
+    #    prob_(alpha == beta) =      1 - 0.186410  = 0.81359
+
+    energy = 1.0 * nt.units.GeV
+    barger = TwoFlavourBarger()
+    barger.set_params(m1=0.04 * nt.units.eV, m2=0.001 * nt.units.eV, theta=0.24,
+                        baseline=500.0 * nt.units.km, density=2.0)
+    
+    def test_vacuum_osc_length(self):
+        self.assertAlmostEqual(self.barger.lv(self.energy), 7.8588934e+12, -6,
+                               f"bad vacuum osc length")
+    
+    def test_matter_osc_length(self):
+        self.assertAlmostEqual(self.barger.lm(), 2.0588727e+13, -6,
+                               f"bad matter osc length")
+    
+    def test_effective_mixing_angle(self):
+        self.assertAlmostEqual(self.barger.calculate_effective_angle(self.energy),0.370219805, 6,
+                               f"bad effective mixing angle")
+    
+    def test_effective_dm2(self):
+        self.assertAlmostEqual(self.barger.calculate_effective_dm2(self.energy),0.00109453, 6,
+                        f"bad effective dm^2")
+
+    def test_survuval(self):
+        self.assertAlmostEqual(self.barger.calculate_prob(self.energy, 1, 1), 0.81359, 5,
+                        f"b->b vacuum prob not as expected")
+        self.assertAlmostEqual(self.barger.calculate_prob(self.energy, 0, 0), 0.81359, 5,
+                        f"a->a vacuum prob not as expected")
+    
+    def test_oscillation(self):
+        self.assertAlmostEqual(self.barger.calculate_prob(self.energy, 0, 1), 0.186410, 5,
+                        f"a->b vacuum prob not as expected")
+        self.assertAlmostEqual(self.barger.calculate_prob(self.energy, 1, 0), 0.186410, 5,
+                        f"b->a vacuum prob not as expected")

--- a/tests/python/two-flavour-const-matter.py
+++ b/tests/python/two-flavour-const-matter.py
@@ -1,0 +1,81 @@
+import unittest
+import math as m
+import nuTens as nt
+from nuTens import tensor
+from nuTens.testing import TwoFlavourBarger
+from nuTens.propagator import ConstDensitySolver
+
+class TestTwoFlavourConstMatter(unittest.TestCase):
+
+    def test_compare_barger(self):
+        energy = 80.0
+        m1=0.1
+        m2=0.15
+        theta=0.88853
+        baseline=295000.0
+        density=2.5
+
+        barger = TwoFlavourBarger()
+        barger.set_params(m1, m2, theta, baseline, density)
+
+        print(f"Barger:"
+              f"alpha={barger.calculate_effective_angle(energy)}, "
+              f"DM^2 ={barger.calculate_effective_dm2(energy)}, \n"
+              f"Probs: \n"
+              f"p_00 ={barger.calculate_prob(energy, i=0, j=0)}, "
+              f"p_01 ={barger.calculate_prob(energy, i=0, j=1)}, "
+              f"p_10 ={barger.calculate_prob(energy, i=1, j=0)}, "
+              f"p_11 ={barger.calculate_prob(energy, i=1, j=1)}, "
+        )
+
+
+        energy_tensor = tensor.ones([1, 1], nt.dtype.scalar_type.complex_float, nt.dtype.device_type.cpu, False)
+        energy_tensor.set_value([0, 0], energy)
+        
+        PMNS = nt.tensor.zeros([1, 2, 2], nt.dtype.scalar_type.complex_float, nt.dtype.device_type.cpu, True)
+        PMNS.set_value([0, 0, 0], m.cos(theta))
+        PMNS.set_value([0, 0, 1], m.sin(theta))
+        PMNS.set_value([0, 1, 0], -m.sin(theta))
+        PMNS.set_value([0, 1, 1], m.cos(theta))
+
+        masses = tensor.zeros([1,2], nt.dtype.scalar_type.float, nt.dtype.device_type.cpu, True)
+        masses.set_value([0,0], m1)
+        masses.set_value([0,1], m2)
+        
+        tensor_solver = ConstDensitySolver(2, density)
+        tensor_solver.set_PMNS(PMNS)
+        tensor_solver.set_masses(masses)
+        tensor_solver.set_energies(energy_tensor)
+
+        evecs = nt.tensor.Tensor()
+        evals = nt.tensor.Tensor()
+
+        tensor_solver.calculate_eigenvalues(evecs, evals)
+
+        print(f"eigenvalues: {evals.to_string()}")
+        print(f"eigenvectors: {evecs.to_string()}")
+
+        PMNSeff = tensor.matmul(PMNS, evecs)
+
+        print(f"Tensor PMNS: \n{PMNSeff.to_string()}")
+
+        print(f"Barger PMNS:\n"
+            f"{barger.get_PMNS_element(energy, i=0, j=0)}, "
+            f"{barger.get_PMNS_element(energy, i=0, j=1)}, \n"
+            f"{barger.get_PMNS_element(energy, i=1, j=0)}, "
+            f"{barger.get_PMNS_element(energy, i=1, j=1)}, "
+        )
+
+
+        self.assertTrue(abs(PMNSeff.get_value([0, 0, 0]) - barger.get_PMNS_element(energy, i=0, j=0)) < 0.0001, 
+                        f"ConstMatterSolver effectivePMNS[0,0] != barger PMNS")
+        self.assertTrue(abs(PMNSeff.get_value([0, 1, 1]) - barger.get_PMNS_element(energy, i=1, j=1)) < 0.0001, 
+                        f"ConstMatterSolver effectivePMNS[1,1] != barger PMNS")
+        self.assertTrue(abs(PMNSeff.get_value([0, 0, 1]) - barger.get_PMNS_element(energy, i=0, j=1)) < 0.0001, 
+                        f"ConstMatterSolver effectivePMNS[0,1] != barger PMNS")
+        self.assertTrue(abs(PMNSeff.get_value([0, 1, 0]) - barger.get_PMNS_element(energy, i=1, j=0)) < 0.0001, 
+                        f"ConstMatterSolver effectivePMNS[1,0] != barger PMNS")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/python/two-flavour-const-matter.py
+++ b/tests/python/two-flavour-const-matter.py
@@ -8,11 +8,11 @@ from nuTens.propagator import ConstDensitySolver
 class TestTwoFlavourConstMatter(unittest.TestCase):
 
     def test_compare_barger(self):
-        energy = 80.0
-        m1=0.1
-        m2=0.15
+        energy = 1.0 * nt.units.GeV
+        m1=0.0
+        m2=0.008 * nt.units.eV
         theta=0.88853
-        baseline=295000.0
+        baseline=295.0 * nt.units.km
         density=2.5
 
         barger = TwoFlavourBarger()
@@ -27,7 +27,6 @@ class TestTwoFlavourConstMatter(unittest.TestCase):
               f"p_10 ={barger.calculate_prob(energy, i=1, j=0)}, "
               f"p_11 ={barger.calculate_prob(energy, i=1, j=1)}, "
         )
-
 
         energy_tensor = tensor.ones([1, 1], nt.dtype.scalar_type.complex_float, nt.dtype.device_type.cpu, False)
         energy_tensor.set_value([0, 0], energy)
@@ -52,9 +51,6 @@ class TestTwoFlavourConstMatter(unittest.TestCase):
 
         tensor_solver.calculate_eigenvalues(evecs, evals)
 
-        print(f"eigenvalues: {evals.to_string()}")
-        print(f"eigenvectors: {evecs.to_string()}")
-
         PMNSeff = tensor.matmul(PMNS, evecs)
 
         print(f"Tensor PMNS: \n{PMNSeff.to_string()}")
@@ -65,7 +61,6 @@ class TestTwoFlavourConstMatter(unittest.TestCase):
             f"{barger.get_PMNS_element(energy, i=1, j=0)}, "
             f"{barger.get_PMNS_element(energy, i=1, j=1)}, "
         )
-
 
         self.assertTrue(abs(PMNSeff.get_value([0, 0, 0]) - barger.get_PMNS_element(energy, i=0, j=0)) < 0.0001, 
                         f"ConstMatterSolver effectivePMNS[0,0] != barger PMNS")

--- a/tests/python/two-flavour-const-matter.py
+++ b/tests/python/two-flavour-const-matter.py
@@ -21,7 +21,7 @@ class TestTwoFlavourConstMatter:
     energy_tensor = tensor.ones([1, 1], nt.dtype.scalar_type.complex_float, nt.dtype.device_type.cpu, False)
     energy_tensor.set_value([0, 0], energy)
 
-    def setup_tensor_inputs(self, mass_diff:float, theta:float) -> typing.Tuple[tensor]:
+    def setup_tensor_inputs(self, mass_diff:float, theta:float) -> typing.Tuple[tensor.Tensor]:
         
         pmns = nt.tensor.zeros([1, 2, 2], nt.dtype.scalar_type.complex_float, nt.dtype.device_type.cpu, True)
         pmns.set_value([0, 0, 0], m.cos(theta))

--- a/tests/python/two-flavour-const-matter.py
+++ b/tests/python/two-flavour-const-matter.py
@@ -5,71 +5,135 @@ from nuTens import tensor
 from nuTens.testing import TwoFlavourBarger
 from nuTens.propagator import ConstDensitySolver
 
-class TestTwoFlavourConstMatter(unittest.TestCase):
+import numpy as np
+import typing
 
-    def test_compare_barger(self):
-        energy = 1.0 * nt.units.GeV
-        m1=0.0
-        m2=0.008 * nt.units.eV
-        theta=0.88853
-        baseline=295.0 * nt.units.km
-        density=2.5
+import pytest
 
-        barger = TwoFlavourBarger()
-        barger.set_params(m1, m2, theta, baseline, density)
 
-        print(f"Barger:"
-              f"alpha={barger.calculate_effective_angle(energy)}, "
-              f"DM^2 ={barger.calculate_effective_dm2(energy)}, \n"
-              f"Probs: \n"
-              f"p_00 ={barger.calculate_prob(energy, i=0, j=0)}, "
-              f"p_01 ={barger.calculate_prob(energy, i=0, j=1)}, "
-              f"p_10 ={barger.calculate_prob(energy, i=1, j=0)}, "
-              f"p_11 ={barger.calculate_prob(energy, i=1, j=1)}, "
-        )
+@pytest.mark.parametrize("mass_diff", np.linspace(0.001, 0.01, 10, True))
+@pytest.mark.parametrize("theta",     np.linspace(0.0, 2.0 * m.pi, 30, True))
+class TestTwoFlavourConstMatter: 
 
-        energy_tensor = tensor.ones([1, 1], nt.dtype.scalar_type.complex_float, nt.dtype.device_type.cpu, False)
-        energy_tensor.set_value([0, 0], energy)
+    baseline=295.0 * nt.units.km
+    density=2.5    
+    energy = 1.0 * nt.units.GeV
+    energy_tensor = tensor.ones([1, 1], nt.dtype.scalar_type.complex_float, nt.dtype.device_type.cpu, False)
+    energy_tensor.set_value([0, 0], energy)
+
+    def setup_tensor_inputs(self, mass_diff:float, theta:float) -> typing.Tuple[tensor]:
         
-        PMNS = nt.tensor.zeros([1, 2, 2], nt.dtype.scalar_type.complex_float, nt.dtype.device_type.cpu, True)
-        PMNS.set_value([0, 0, 0], m.cos(theta))
-        PMNS.set_value([0, 0, 1], m.sin(theta))
-        PMNS.set_value([0, 1, 0], -m.sin(theta))
-        PMNS.set_value([0, 1, 1], m.cos(theta))
+        pmns = nt.tensor.zeros([1, 2, 2], nt.dtype.scalar_type.complex_float, nt.dtype.device_type.cpu, True)
+        pmns.set_value([0, 0, 0], m.cos(theta))
+        pmns.set_value([0, 0, 1], m.sin(theta))
+        pmns.set_value([0, 1, 0], -m.sin(theta))
+        pmns.set_value([0, 1, 1], m.cos(theta))
 
         masses = tensor.zeros([1,2], nt.dtype.scalar_type.float, nt.dtype.device_type.cpu, True)
-        masses.set_value([0,0], m1)
-        masses.set_value([0,1], m2)
-        
-        tensor_solver = ConstDensitySolver(2, density)
-        tensor_solver.set_PMNS(PMNS)
-        tensor_solver.set_masses(masses)
-        tensor_solver.set_energies(energy_tensor)
+        masses.set_value([0,0], 0.0)
+        masses.set_value([0,1], mass_diff)
 
+        return pmns, masses
+
+    def test_compare_effective_PMNS(self, mass_diff:float, theta:float):
+
+        # set up barger
+        barger = TwoFlavourBarger()
+        barger.set_params(m1=0.0, m2=mass_diff, theta=theta, baseline=self.baseline, density=self.density)
+        
+        pmns, masses = self.setup_tensor_inputs(mass_diff, theta)
+
+        # set up tensor solver
+        tensor_solver = ConstDensitySolver(2, self.density)
+        tensor_solver.set_PMNS(pmns)
+        tensor_solver.set_masses(masses)
+        tensor_solver.set_energies(self.energy_tensor)
+
+        # calculate the evals + evecs to print for help when debugging
         evecs = nt.tensor.Tensor()
         evals = nt.tensor.Tensor()
-
         tensor_solver.calculate_eigenvalues(evecs, evals)
 
-        PMNSeff = tensor.matmul(PMNS, evecs)
+        tensor_effective_pmns = tensor.matmul(pmns, evecs)
 
-        print(f"Tensor PMNS: \n{PMNSeff.to_string()}")
+        print(f"Tensor solver evals: {evals.to_string()}")
+
+        print(f"Tensor solver evecs: {evecs.to_string()}")
+
+        print(f"Tensor PMNS: \n{tensor_effective_pmns.to_string()}")
 
         print(f"Barger PMNS:\n"
-            f"{barger.get_PMNS_element(energy, i=0, j=0)}, "
-            f"{barger.get_PMNS_element(energy, i=0, j=1)}, \n"
-            f"{barger.get_PMNS_element(energy, i=1, j=0)}, "
-            f"{barger.get_PMNS_element(energy, i=1, j=1)}, "
+            f"{barger.get_PMNS_element(self.energy, i=0, j=0)}, "
+            f"{barger.get_PMNS_element(self.energy, i=0, j=1)}, \n"
+            f"{barger.get_PMNS_element(self.energy, i=1, j=0)}, "
+            f"{barger.get_PMNS_element(self.energy, i=1, j=1)}, "
         )
 
-        self.assertTrue(abs(PMNSeff.get_value([0, 0, 0]) - barger.get_PMNS_element(energy, i=0, j=0)) < 0.0001, 
-                        f"ConstMatterSolver effectivePMNS[0,0] != barger PMNS")
-        self.assertTrue(abs(PMNSeff.get_value([0, 1, 1]) - barger.get_PMNS_element(energy, i=1, j=1)) < 0.0001, 
-                        f"ConstMatterSolver effectivePMNS[1,1] != barger PMNS")
-        self.assertTrue(abs(PMNSeff.get_value([0, 0, 1]) - barger.get_PMNS_element(energy, i=0, j=1)) < 0.0001, 
-                        f"ConstMatterSolver effectivePMNS[0,1] != barger PMNS")
-        self.assertTrue(abs(PMNSeff.get_value([0, 1, 0]) - barger.get_PMNS_element(energy, i=1, j=0)) < 0.0001, 
-                        f"ConstMatterSolver effectivePMNS[1,0] != barger PMNS")
+        assert (
+            pytest.approx(abs(tensor_effective_pmns.get_value([0, 0, 0])), abs = 1e-6) == abs(barger.get_PMNS_element(self.energy, i=0, j=0))
+            ), f"ConstMatterSolver effectivePMNS[0,0] != barger PMNS"
+        assert (
+            pytest.approx(abs(tensor_effective_pmns.get_value([0, 0, 1])), abs = 1e-6) == abs(barger.get_PMNS_element(self.energy, i=0, j=1))
+            ), f"ConstMatterSolver effectivePMNS[0,0] != barger PMNS"
+        assert (
+            pytest.approx(abs(tensor_effective_pmns.get_value([0, 1, 0])), abs = 1e-6) == abs(barger.get_PMNS_element(self.energy, i=1, j=0))
+            ), f"ConstMatterSolver effectivePMNS[0,0] != barger PMNS"
+        assert (
+            pytest.approx(abs(tensor_effective_pmns.get_value([0, 1, 1])), abs = 1e-6) == abs(barger.get_PMNS_element(self.energy, i=1, j=1))
+            ), f"ConstMatterSolver effectivePMNS[0,0] != barger PMNS"
+
+
+    def test_compare_osc_probs(self, mass_diff:float, theta:float):
+
+        # set up barger
+        barger = TwoFlavourBarger()
+        barger.set_params(m1=0.0, m2=mass_diff, theta=theta, baseline=self.baseline, density=self.density)
+        
+        pmns, masses = self.setup_tensor_inputs(mass_diff, theta)
+
+        # set up tensor solver
+        propagator = nt.propagator.Propagator(2, self.baseline)
+        matter_solver = ConstDensitySolver(2, self.density)
+        
+        propagator.set_PMNS(pmns)
+        propagator.set_masses(masses)
+        propagator.set_matter_solver(matter_solver)
+        propagator.set_energies(self.energy_tensor)
+
+        # calculate the evals + evecs + effective PMNS to print 
+        # for help when debugging
+        evecs = nt.tensor.Tensor()
+        evals = nt.tensor.Tensor()
+        matter_solver.calculate_eigenvalues(evecs, evals)
+        tensor_effective_pmns = tensor.matmul(pmns, evecs)
+
+        tensor_osc_probs = propagator.calculate_probabilities()
+
+        print(f"Tensor solver evals: {evals.to_string()}")
+
+        print(f"Tensor solver evecs: {evecs.to_string()}")
+
+        print(f"Tensor PMNS: \n{tensor_effective_pmns.to_string()}")
+
+        print(f"Barger PMNS:\n"
+            f"{barger.get_PMNS_element(self.energy, i=0, j=0)}, "
+            f"{barger.get_PMNS_element(self.energy, i=0, j=1)}, \n"
+            f"{barger.get_PMNS_element(self.energy, i=1, j=0)}, "
+            f"{barger.get_PMNS_element(self.energy, i=1, j=1)}, "
+        )
+
+        assert (
+            pytest.approx(abs(tensor_osc_probs.get_value([0, 0, 0])), abs = 1e-6) == abs(barger.calculate_prob(self.energy, i=0, j=0))
+            ), f"Const matter osc prob[0,0] != barger osc prob"
+        assert (
+            pytest.approx(abs(tensor_osc_probs.get_value([0, 0, 1])), abs = 1e-6) == abs(barger.calculate_prob(self.energy, i=0, j=1))
+            ), f"Const matter osc prob[0,1] != barger osc prob"
+        assert (
+            pytest.approx(abs(tensor_osc_probs.get_value([0, 1, 0])), abs = 1e-6) == abs(barger.calculate_prob(self.energy, i=1, j=0))
+            ), f"Const matter osc prob[1,0] != barger osc prob"
+        assert (
+            pytest.approx(abs(tensor_osc_probs.get_value([0, 1, 1])), abs = 1e-6) == abs(barger.calculate_prob(self.energy, i=1, j=1))
+            ), f"Const matter osc prob[1,1] != barger osc prob"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add some tests using the python interface, run them in the python CI action using pytest

- This required adding binding for test-utils library, mainly so that we can access the Barger propagator in the python tests
- Just now only test the barger propagator and const density matter oscillations. will add more in future.
- Moved the existing "tests" to more suitable "examples" folder

Reson for failing tests currently is #76, which I think I know how to fix... stay tuned
