### PR TITLE
use torch::linalg_eigh instead of torch::linalg_eig

### DIFF
--- a/nuTens/propagator/const-density-solver.cpp
+++ b/nuTens/propagator/const-density-solver.cpp
@@ -14,5 +14,5 @@ void ConstDensityMatterSolver::calculateEigenvalues(Tensor &eigenvectors, Tensor
         }
     }
 
-    Tensor::eig(hamiltonian, eigenvectors, eigenvalues);
+    Tensor::eigh(hamiltonian, eigenvectors, eigenvalues);
 }

--- a/nuTens/tensors/tensor.hpp
+++ b/nuTens/tensors/tensor.hpp
@@ -226,6 +226,14 @@ class Tensor
     /// @param[out] eVecs The eigenvectors
     static void eig(const Tensor &t, Tensor &eVals, Tensor &eVecs);
 
+    /// @brief Get eigenvalues and vectors of a hermitian matrix
+    /// @arg t The tensor
+    /// @param[out] eVals The eigenvalues
+    /// @param[out] eVecs The eigenvectors
+    /// This is in general faster and more stable than @ref Tensor::eig
+    /// and should be preferred in basically all cases where it can be used
+    static void eigh(const Tensor &t, Tensor &eVals, Tensor &eVecs);
+
     /// @}
 
     /// @name Mathematical

--- a/nuTens/tensors/torch-tensor.cpp
+++ b/nuTens/tensors/torch-tensor.cpp
@@ -406,6 +406,15 @@ void Tensor::eig(const Tensor &t, Tensor &eVals, Tensor &eVecs)
     eVecs._tensor = std::get<0>(ret);
 }
 
+void Tensor::eigh(const Tensor &t, Tensor &eVals, Tensor &eVecs)
+{
+    NT_PROFILE();
+
+    auto ret = torch::linalg_eigh(t._tensor);
+    eVals._tensor = std::get<1>(ret);
+    eVecs._tensor = std::get<0>(ret);
+}
+
 Tensor Tensor::real() const
 {
     NT_PROFILE();


### PR DESCRIPTION
the ordering of eigenvalues and eigenvectors in linalg_eig is not guarenteed, but for linalg_eigh they are in ascending order of the eigenvalues. This means that the calculation of the effective matrix using the matter solver is more stable and matches the prediction from the Barger propagator. It may also be faster. It does require the input matrix to be hermitian but since we are using it to deal with Hamiltonians this shouldn't be a problem.

fixes #76 
closes #78 

*edit* ok after running benchmark it seems like it's a **lot** faster!