### PR TITLE
properly initialise the tensor in the zeros builder function

### DIFF
--- a/nuTens/propagator/base-matter-solver.hpp
+++ b/nuTens/propagator/base-matter-solver.hpp
@@ -33,7 +33,7 @@ class BaseMatterSolver
       energies = newEnergies;
       energiesRed = energies.getValues({"...", 0});
 
-      hamiltonian = Tensor::zeros({energies.getBatchDim(), nGenerations, nGenerations}, NTdtypes::kComplexFloat);
+      hamiltonian = Tensor::zeros({energies.getBatchDim(), nGenerations, nGenerations}, NTdtypes::kComplexFloat).requiresGrad(false);
     }
 
     /// @}

--- a/nuTens/propagator/const-density-solver.hpp
+++ b/nuTens/propagator/const-density-solver.hpp
@@ -36,7 +36,7 @@ class ConstDensityMatterSolver : public BaseMatterSolver
     /// @arg density The electron density of the material to propagate in
     ConstDensityMatterSolver(int nGenerations, float density) : BaseMatterSolver(nGenerations), density(density)
     {
-        diagMassMatrix = Tensor::zeros({1, nGenerations, nGenerations}, NTdtypes::kFloat);
+        diagMassMatrix = Tensor::zeros({1, nGenerations, nGenerations}, NTdtypes::kFloat).requiresGrad(false);
     };
 
     /// @name Setters

--- a/nuTens/tensors/torch-tensor.cpp
+++ b/nuTens/tensors/torch-tensor.cpp
@@ -83,7 +83,10 @@ Tensor Tensor::zeros(const std::vector<long int> &shape, NTdtypes::scalarType ty
     NT_PROFILE();
 
     Tensor ret;
-    ret.setTensor(torch::zeros(c10::IntArrayRef(shape), NTdtypes::scalarTypeMap(type)));
+    ret.setTensor(torch::zeros(c10::IntArrayRef(shape), torch::TensorOptions()
+                                                           .dtype(NTdtypes::scalarTypeMap(type))
+                                                           .device(NTdtypes::deviceTypeMap(device))
+                                                           .requires_grad(requiresGrad)));
     ret._dType = type;
     ret._device = device;
     return ret;

--- a/tests/python/test_two-flavour-const-matter.py
+++ b/tests/python/test_two-flavour-const-matter.py
@@ -23,13 +23,13 @@ class TestTwoFlavourConstMatter:
 
     def setup_tensor_inputs(self, mass_diff:float, theta:float) -> typing.Tuple[Tensor]:
         
-        pmns = Tensor.zeros([1, 2, 2], nt.dtype.scalar_type.complex_float, nt.dtype.device_type.cpu, True)
+        pmns = Tensor.zeros([1, 2, 2], nt.dtype.scalar_type.complex_float, nt.dtype.device_type.cpu, False)
         pmns.set_value([0, 0, 0], m.cos(theta))
         pmns.set_value([0, 0, 1], m.sin(theta))
         pmns.set_value([0, 1, 0], -m.sin(theta))
         pmns.set_value([0, 1, 1], m.cos(theta))
 
-        masses = Tensor.zeros([1,2], nt.dtype.scalar_type.float, nt.dtype.device_type.cpu, True)
+        masses = Tensor.zeros([1,2], nt.dtype.scalar_type.float, nt.dtype.device_type.cpu, False)
         masses.set_value([0,0], 0.0)
         masses.set_value([0,1], mass_diff)
 

--- a/tests/tensor-basic.cpp
+++ b/tests/tensor-basic.cpp
@@ -117,7 +117,7 @@ int main()
         return 1;
     }
 
-    Tensor complexGradTest = Tensor::zeros({2, 2}, NTdtypes::kComplexFloat);
+    Tensor complexGradTest = Tensor::zeros({2, 2}, NTdtypes::kComplexFloat).requiresGrad(false);
     complexGradTest.setValue({0, 0}, std::complex<float>(0.0 + 0.0J));
     complexGradTest.setValue({0, 1}, std::complex<float>(0.0 + 1.0J));
     complexGradTest.setValue({1, 0}, std::complex<float>(1.0 + 0.0J));


### PR DESCRIPTION
Now use the TensorOptions class.

Seems like before supplied device and requiresGrad options were being ignored but was fine as everywhere just now was only using cpu tensors and not requiring gradients