### PR TITLE
bugfix: stop truncating values in setValue methods

### DIFF
--- a/nuTens/tensors/tensor.hpp
+++ b/nuTens/tensors/tensor.hpp
@@ -332,7 +332,9 @@ class Tensor
     void setValue(const Tensor &indices, const Tensor &value);
     void setValue(const std::vector<indexType> &indices, const Tensor &value);
     void setValue(const std::vector<int> &indices, float value);
+    void setValue(const std::vector<int> &indices, double value);
     void setValue(const std::vector<int> &indices, std::complex<float> value);
+    void setValue(const std::vector<int> &indices, std::complex<double> value);
 
     /// @brief Get the value at a certain entry in the tensor
     /// @param indices The index of the entry to get

--- a/nuTens/tensors/torch-tensor.cpp
+++ b/nuTens/tensors/torch-tensor.cpp
@@ -186,11 +186,25 @@ void Tensor::setValue(const std::vector<int> &indices, float value)
     _tensor.index_put_(convertIndices(indices), value);
 }
 
+void Tensor::setValue(const std::vector<int> &indices, double value)
+{
+    NT_PROFILE();
+
+    _tensor.index_put_(convertIndices(indices), value);
+}
+
 void Tensor::setValue(const std::vector<int> &indices, std::complex<float> value)
 {
     NT_PROFILE();
 
     _tensor.index_put_(convertIndices(indices), c10::complex<float>(value.real(), value.imag()));
+}
+
+void Tensor::setValue(const std::vector<int> &indices, std::complex<double> value)
+{
+    NT_PROFILE();
+
+    _tensor.index_put_(convertIndices(indices), c10::complex<double>(value.real(), value.imag()));
 }
 
 size_t Tensor::getNdim() const

--- a/python/binding.cpp
+++ b/python/binding.cpp
@@ -97,10 +97,17 @@ void initTensor(py::module &m)
             "Set a value at a specific index of this tensor",
             py::arg("indices"), py::arg("value")
         )
+        .def("set_value", py::overload_cast<const std::vector<int> &, double>(&Tensor::setValue),
+            "Set a value at a specific index of this tensor",
+            py::arg("indices"), py::arg("value")
+        )
         .def("set_value", py::overload_cast<const std::vector<int> &, std::complex<float>>(&Tensor::setValue),
             "Set a value at a specific index of this tensor",
             py::arg("indices"), py::arg("value")
         )
+        .def("set_value", py::overload_cast<const std::vector<int> &, std::complex<double>>(&Tensor::setValue),
+            "Set a value at a specific index of this tensor",
+            py::arg("indices"), py::arg("value"))
 
         // getters
         .def("get_shape", &Tensor::getShape, "Get the shape of this tensor")


### PR DESCRIPTION
add overloads for double precision floats for single value setValue methods in Tensor.

Previously this might cause the values to get truncated. I think this would be the case especially in python since it uses double precision floats.

Now should be no data loss.

fixes #85 