### PR TITLE
nuTens as cmake package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,4 +97,32 @@ foreach (_variableName ${_variableNames})
     message(STATUS "  ${_variableName}=${${_variableName}}")
 endforeach()
 
+install(EXPORT nuTens-targets
+  FILE nuTensTargets.cmake
+  DESTINATION lib/cmake/nuTens
+)
+
+include(CMakePackageConfigHelpers)
+
+# generate the config file that includes the exports
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/templates/nuTensConfig.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/nuTensConfig.cmake"
+  INSTALL_DESTINATION "lib/cmake/nuTens"
+  NO_SET_AND_CHECK_MACRO
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+
+write_basic_package_version_file(${CMAKE_BINARY_DIR}/nuTensConfigVersion.cmake
+  VERSION ${nuTens_VERSION}
+  COMPATIBILITY AnyNewerVersion)
+
+install(FILES
+  ${CMAKE_BINARY_DIR}/nuTensConfig.cmake
+  ${CMAKE_BINARY_DIR}/nuTensConfigVersion.cmake
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/nuTens)
+  
+ export(EXPORT nuTens-targets
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/nuTensTargets.cmake"
+)
+
 include(cmake/nuTens-config.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ foreach (_variableName ${_variableNames})
     
     message(STATUS "  ${_variableName}=${${_variableName}}")
 endforeach()
+message(STATUS "  BUILD_SHARED_LIB=${BUILD_SHARED_LIBS}")
 
 install(EXPORT nuTens-targets
   FILE nuTensTargets.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,10 @@ elseif(NOT DEFINED CMAKE_INSTALL_PREFIX)
 endif()
 
 # user options
+option(NT_USE_TORCH "Use torch as the backend for dealing with tensors" ON)
+option(NT_TORCH_FROM_PIP "If it is not found, torch will be installed using pip" ON)
+option(NT_TORCH_FROM_SCRATCH "If it is not found, torch will be compiled from scratch using CPM (very slow but maybe useful for debugging builds)" OFF)
+option(NT_ALLOW_GLOBAL_PYTHON_ENV "Allow installing pip packages in global python environment" OFF)
 option(NT_ENABLE_BENCHMARKING "enable benchmarking using google benchmark" OFF)
 option(NT_ENABLE_PYTHON "enable python interface" OFF)
 option(NT_COMPILE_TESTS "whether or not to compile unit and integration tests" ON)
@@ -92,3 +96,5 @@ foreach (_variableName ${_variableNames})
     
     message(STATUS "  ${_variableName}=${${_variableName}}")
 endforeach()
+
+include(cmake/nuTens-config.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(NT_COMPILE_TESTS "whether or not to compile unit and integration tests" O
 option(NT_TEST_COVERAGE "produce code coverage reports when running tests" OFF)
 option(NT_BUILD_TIMING "output time to build each target" OFF)
 option(NT_USE_PCH "NT_USE_PCH" OFF)
+option(BUILD_SHARED_LIBS "Build using shared libs" ON)
 
 ## to build the python library we require to build with the pic flag
 if(NT_ENABLE_PYTHON)

--- a/cmake/nuTens-config.cmake
+++ b/cmake/nuTens-config.cmake
@@ -1,0 +1,18 @@
+SET(nuTens_LIB_LIST "-libtensor -libpropagator -libinstrumentation -libnt-logging -libconstants -libunits")
+
+SET(nuTens_FEATURES_LIST)
+
+if(UseGPU EQUAL 1)
+  LIST(APPEND NUOSCILLATOR_FEATURES_LIST "GPU")
+endif()
+LIST(APPEND NUOSCILLATOR_FEATURES_LIST ${NuOscillator_Engines_Enabled})
+
+# Set the creation date
+string(TIMESTAMP CREATION_DATE "%d-%m-%Y")
+
+string(REPLACE ";" " " nuTens_FEATURES "${nuTens_FEATURES_LIST}")
+configure_file(${CMAKE_CURRENT_LIST_DIR}/templates/nuTens-config.in
+  "${PROJECT_BINARY_DIR}/nuTens-config" @ONLY)
+install(PROGRAMS
+  "${PROJECT_BINARY_DIR}/nuTens-config" DESTINATION
+  bin)

--- a/cmake/nuTens-config.cmake
+++ b/cmake/nuTens-config.cmake
@@ -1,4 +1,4 @@
-SET(nuTens_LIB_LIST "-libtensor -libpropagator -libinstrumentation -libnt-logging -libconstants -libunits")
+SET(nuTens_LIB_LIST "-lnuTens -libtensor -libpropagator -libinstrumentation -libnt-logging -libconstants -libunits")
 
 SET(nuTens_FEATURES_LIST)
 

--- a/cmake/nuTens-config.cmake
+++ b/cmake/nuTens-config.cmake
@@ -2,10 +2,21 @@ SET(nuTens_LIB_LIST "-lnuTens -libtensor -libpropagator -libinstrumentation -lib
 
 SET(nuTens_FEATURES_LIST)
 
-if(UseGPU EQUAL 1)
-  LIST(APPEND NUOSCILLATOR_FEATURES_LIST "GPU")
+if(NT_ENABLE_PYTHON EQUAL 1)
+  LIST(APPEND nuTens_FEATURES_LIST "python")
 endif()
-LIST(APPEND NUOSCILLATOR_FEATURES_LIST ${NuOscillator_Engines_Enabled})
+if(NT_USE_TORCH EQUAL 1)
+  LIST(APPEND nuTens_FEATURES_LIST "torch")
+endif()
+if(NT_ENABLE_BENCHMARKING EQUAL 1)
+  LIST(APPEND nuTens_FEATURES_LIST "benchmarks")
+endif()
+if(NT_COMPILE_TESTS EQUAL 1)
+  LIST(APPEND nuTens_FEATURES_LIST "tests")
+endif()
+if(NT_TEST_COVERAGE EQUAL 1)
+  LIST(APPEND nuTens_FEATURES_LIST "test-coverage")
+endif()
 
 # Set the creation date
 string(TIMESTAMP CREATION_DATE "%d-%m-%Y")

--- a/cmake/nuTens-dependencies.cmake
+++ b/cmake/nuTens-dependencies.cmake
@@ -74,7 +74,11 @@ message("Torch cxx flags: ${TORCH_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
 
 ## ==== spdlog ====
-CPMAddPackage("gh:gabime/spdlog@1.8.2")
+CPMFindPackage(
+    NAME spdlog
+    GITHUB_REPOSITORY gabime/spdlog
+    VERSION 1.8.2
+)
 
 # ==== google benchmark ====
 if(NT_ENABLE_BENCHMARKING)

--- a/cmake/nuTens-dependencies.cmake
+++ b/cmake/nuTens-dependencies.cmake
@@ -1,15 +1,75 @@
 ## define dependencies of nutens which will be included using cpm where possible
 
 ## ==== Pytorch ====
-find_package(Torch)
-if( NOT Torch_FOUND )
-    message( "didn't find pytorch, will try installing using cpm" )
+if(NT_USE_TORCH)
+    find_package(Torch)
 
-    CPMAddPackage("gh:pytorch/pytorch@2.7.1")
-    find_package(Torch REQUIRED)
-  #set( Torch_FOUND TRUE)
-endif()
+    if(Torch_FOUND)
+        message(STATUS "Found pre-installed Torch at ${Torch_DIR}")
+    
+    elseif(NT_TORCH_FROM_PIP)
+        
+        message(STATUS "Torch not found - installing with pip")
+        
+        ## check if we are in a virtual environment before pip installing
+        if(DEFINED ENV{VIRTUAL_ENV} OR DEFINED ENV{CONDA_PREFIX})
+            set(_pip_args)
+ 
+        else()
+            ## we're not in a virtual env, make sure the user is really sure that's ok
+            if(NT_ALLOW_GLOBAL_PYTHON_ENV)
+                set(_pip_args "--user")
+            else()
+                message(FATAL_ERROR "\
+You're not in a python virtual environment but trying to install pytorch! \n \
+This is ill advised, but if you're sure that's what you want to do you can set the option \n \
+  -D NT_ALLOW_GLOBAL_PYTHON_ENV")
 
+            endif() ## end of if(NT_ALLOW_GLOBAL_PYTHON_ENV)
+
+        endif() ## done checking for virtual env 
+        
+        find_package(Python COMPONENTS Interpreter REQUIRED)
+        
+        ## install torch Python package using pip
+        execute_process(COMMAND ${Python_EXECUTABLE} -m pip install -r ${CMAKE_SOURCE_DIR}/PyTorch_requirements.txt)
+        
+        ## need to do some absolute tomfoolery to get the path to the torch shared library
+        execute_process(
+            COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/cmake/torch-cmake-prefix.py
+            OUTPUT_VARIABLE _TORCH_CMAKE_PREFIX
+        )
+        string(REPLACE ' "" TORCH_CMAKE_PREFIX ${_TORCH_CMAKE_PREFIX})
+
+        message(STATUS "TORCH CMAKE PREFIX: ${TORCH_CMAKE_PREFIX}")
+        list(APPEND CMAKE_PREFIX_PATH ${TORCH_CMAKE_PREFIX})
+    
+    elseif(NT_TORCH_FROM_SCRATCH)
+
+        CPMAddPackage(
+            NAME Torch
+            GIT_REPOSITORY git@github.com:pytorch/pytorch.git
+            VERSION 2.7.1
+        )
+
+    else()
+        message(FATAL_ERROR "\
+Torch not found and no method specified to install it. \n \
+either go install torch and try again or set one of\n \
+    -DNT_TORCH_FROM_PIP=ON\n \
+    -DNT_TORCH_FROM_SCRATCH=ON 
+")
+
+    endif() ## end of if(Torch_FOUND)
+
+endif() ## end of if(NT_USE_TORCH)
+
+message("CMAKE_PREFIX_PATH: ${CMAKE_PREFIX_PATH}")
+execute_process(COMMAND ls ${CMAKE_PREFIX_PATH})
+find_package(Torch REQUIRED)
+
+message(STATUS "Torch DIR ${TORCH_DIR}")
+message(STATUS "Torch libs ${TORCH_LIBS}")
 message("Torch cxx flags: ${TORCH_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
 

--- a/cmake/nuTens-dependencies.cmake
+++ b/cmake/nuTens-dependencies.cmake
@@ -1,14 +1,15 @@
 ## define dependencies of nutens which will be included using cpm where possible
 
-## ==== Protobuf ====
-find_package(Protobuf)
-if( !Protobuf_FOUND )
-  message( "didn't find protobuf, will try installing using cpm" )
-  CPMAddPackage("gh:protocolbuffer/protobuf@27.4")
+## ==== Pytorch ====
+find_package(Torch)
+if( NOT Torch_FOUND )
+    message( "didn't find pytorch, will try installing using cpm" )
+
+    CPMAddPackage("gh:pytorch/pytorch@2.7.1")
+    find_package(Torch REQUIRED)
+  #set( Torch_FOUND TRUE)
 endif()
 
-## ==== Pytorch ====
-find_package(Torch REQUIRED)
 message("Torch cxx flags: ${TORCH_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
 

--- a/cmake/templates/nuTens-config.in
+++ b/cmake/templates/nuTens-config.in
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+#Modify this if moving install from original prefix
+INSTALL_ROOT="@CMAKE_INSTALL_PREFIX@"
+SCRIPTNAME=$0
+CREATION_DATE="@CREATION_DATE@"
+
+# Function to print the help message
+print_help() {
+    echo "[RUNLIKE] ${SCRIPTNAME}"
+    echo -e "\t--incdir                   : Print location of installed header files."
+    echo -e "\t--cflags                   : Print compiler include flag for installed header files."
+    echo -e "\t--libdir                   : Print location of installed libraries."
+    echo -e "\t--libs                     : Print list of nuTens library names."
+    echo -e "\t--features                 : Print list of features."
+    echo -e "\t--has-feature <feature>    : Returns 0 if has feature, 1 if not."
+    echo -e "\t--version                  : Print nuTens version."
+    echo -e "\t--date                     : Print creation date."
+    echo -e "\t-?|--help                  : Print this message."
+    exit 0
+}
+
+if [ ${#} -eq 0 ]; then
+  print_help
+  exit 0
+fi
+
+while [[ ${#} -gt 0 ]]; do
+
+  key="$1"
+  case $key in
+      --incdir)
+      echo -n "${INSTALL_ROOT}/include "
+      ;;
+
+      --cflags)
+      echo -n "-I${INSTALL_ROOT}/include @ROOT_INCLUDE_DIRS_SEP@ @ROOT_DEFINITIONS_SEP@"
+      ;;
+
+      --libdir)
+      echo -n "${INSTALL_ROOT}/lib "
+      ;;
+
+      --libs)
+      echo -n "-L${INSTALL_ROOT}/lib @nuTens_LIB_LIST@"
+      ;;
+
+      --features)
+      echo -n "@nuTens_FEATURES@ "
+      ;;
+
+      --has-feature)
+      shift
+      TEST_FEATURE=$1
+        if [[ "@nuTens_FEATURES@" =~ (^|[[:space:]])${TEST_FEATURE}($|[[:space:]]) ]]; then
+          exit 0
+        else
+          exit 1
+        fi
+      ;;
+
+      --version)
+      echo -n "@nuTens_VERSION@ "
+      ;;
+
+      --date)
+      echo -n "${CREATION_DATE} "
+      ;;
+
+      -?|--help)
+      print_help
+      exit 0
+      ;;
+
+      *)
+              # unknown option
+      echo "Unknown option $1"
+      exit 1
+      ;;
+  esac
+  shift # past argument or value
+done
+echo ""

--- a/cmake/templates/nuTensConfig.cmake.in
+++ b/cmake/templates/nuTensConfig.cmake.in
@@ -28,7 +28,7 @@ find_path(nuTens_INCLUDE_DIR
 )
 
 find_path(nuTens_LIB_DIR
-  NAME libtensor.a
+  NAME libtensor.so
   PATHS ${nuTens_CMAKE_DIR}/lib/
 )
 

--- a/cmake/templates/nuTensConfig.cmake.in
+++ b/cmake/templates/nuTensConfig.cmake.in
@@ -1,0 +1,53 @@
+@PACKAGE_INIT@
+
+set(nuTens_VERSION @PROJECT_VERSION@)
+
+LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../cmake)
+
+get_filename_component(nuTens_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+list(APPEND CMAKE_MODULE_PATH "${nuTens_CMAKE_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${nuTens_CMAKE_DIR}/cmake")
+
+enable_language(CXX)
+
+set(nuTens_FOUND TRUE)
+
+find_package(Torch REQUIRED)
+
+get_filename_component(nuTens_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+include(${CMAKE_CURRENT_LIST_DIR}/nuTensTargets.cmake)
+
+if(NOT TARGET nuTens)
+  cmessage(FATAL_ERROR "Didn't set up nuTens")
+endif()
+
+find_path(nuTens_INCLUDE_DIR
+  NAME tensor/tensor.hpp
+  PATHS ${nuTens_CMAKE_DIR}/include/
+)
+
+find_path(nuTens_LIB_DIR
+  NAME libtensor.a
+  PATHS ${nuTens_CMAKE_DIR}/lib/
+)
+
+find_path(nuTens_PREFIX
+  NAME nuTens-config
+  PATHS ${nuTens_CMAKE_DIR}/
+)
+
+cmessage(STATUS "nuTens_LIB_DIR: ${nuTens_LIB_DIR}")
+cmessage(STATUS "nuTens_INCLUDE_DIR: ${nuTens_INCLUDE_DIR}")
+cmessage(STATUS "nuTens_PREFIX: ${nuTens_PREFIX}")
+cmessage(STATUS "nuTens_VERSION: ${nuTens_VERSION}")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(nuTens
+    REQUIRED_VARS
+      nuTens_INCLUDE_DIR
+      nuTens_LIB_DIR
+      nuTens_PREFIX
+    VERSION_VAR
+      nuTens_VERSION
+)

--- a/cmake/torch-cmake-prefix.py
+++ b/cmake/torch-cmake-prefix.py
@@ -1,0 +1,3 @@
+import torch
+
+print(torch.utils.cmake_prefix_path, end="")

--- a/nuTens/CMakeLists.txt
+++ b/nuTens/CMakeLists.txt
@@ -5,3 +5,15 @@ add_subdirectory(propagator)
 
 add_library(nuTens INTERFACE)
 target_link_libraries(nuTens INTERFACE tensor propagator)
+
+target_include_directories(nuTens
+                           INTERFACE
+                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                            $<INSTALL_INTERFACE:include>
+                           )
+
+install(
+  TARGETS nuTens
+  DESTINATION lib
+  EXPORT nuTens-targets
+)

--- a/nuTens/propagator/CMakeLists.txt
+++ b/nuTens/propagator/CMakeLists.txt
@@ -1,12 +1,12 @@
 
 
-add_library( constants STATIC constants.hpp)
-add_library( units STATIC units.hpp)
+add_library( constants SHARED constants.hpp)
+add_library( units SHARED units.hpp)
 set_target_properties(constants PROPERTIES LINKER_LANGUAGE CXX)
 set_target_properties(units PROPERTIES LINKER_LANGUAGE CXX)
 
 add_library(
-    propagator STATIC 
+    propagator SHARED
     propagator.hpp propagator.cpp 
     const-density-solver.hpp const-density-solver.cpp
 )

--- a/nuTens/propagator/CMakeLists.txt
+++ b/nuTens/propagator/CMakeLists.txt
@@ -23,7 +23,11 @@ if(NT_USE_PCH)
     target_precompile_headers(propagator REUSE_FROM nuTens-pch)
 endif()
 
-target_include_directories(propagator PUBLIC "${CMAKE_SOURCE_DIR}")
+target_include_directories(propagator PUBLIC 
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
 set_target_properties(propagator PROPERTIES LINKER_LANGUAGE CXX)
 
 ## install headers to "include" directory
@@ -31,4 +35,8 @@ set(HEADERS "constants.hpp;units.hpp;propagator.hpp;const-density-solver.hpp;bas
 install(FILES ${HEADERS} DESTINATION include/propagator)
 
 ## install libraries to the "lib" directory
-install(TARGETS propagator DESTINATION lib)
+install(
+    TARGETS propagator constants units
+    DESTINATION lib
+    EXPORT nuTens-targets
+)

--- a/nuTens/propagator/CMakeLists.txt
+++ b/nuTens/propagator/CMakeLists.txt
@@ -25,3 +25,10 @@ endif()
 
 target_include_directories(propagator PUBLIC "${CMAKE_SOURCE_DIR}")
 set_target_properties(propagator PROPERTIES LINKER_LANGUAGE CXX)
+
+## install headers to "include" directory
+set(HEADERS "constants.hpp;units.hpp;propagator.hpp;const-density-solver.hpp;base-matter-solver.hpp")
+install(FILES ${HEADERS} DESTINATION include/propagator)
+
+## install libraries to the "lib" directory
+install(TARGETS propagator DESTINATION lib)

--- a/nuTens/propagator/CMakeLists.txt
+++ b/nuTens/propagator/CMakeLists.txt
@@ -1,12 +1,12 @@
 
 
-add_library( constants SHARED constants.hpp)
-add_library( units SHARED units.hpp)
+add_library( constants constants.hpp)
+add_library( units units.hpp)
 set_target_properties(constants PROPERTIES LINKER_LANGUAGE CXX)
 set_target_properties(units PROPERTIES LINKER_LANGUAGE CXX)
 
 add_library(
-    propagator SHARED
+    propagator
     propagator.hpp propagator.cpp 
     const-density-solver.hpp const-density-solver.cpp
 )

--- a/nuTens/tensors/CMakeLists.txt
+++ b/nuTens/tensors/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-if(Torch_FOUND)
+if(NT_USE_TORCH)
     add_library(tensor STATIC tensor.hpp torch-tensor.cpp)
     target_compile_definitions(tensor PUBLIC USE_PYTORCH)
 endif()
@@ -12,3 +12,10 @@ endif()
 
 target_link_libraries(tensor PUBLIC utils)
 set_target_properties(tensor PROPERTIES LINKER_LANGUAGE CXX)
+
+## install headers to "include" directory
+set(HEADERS "tensor.hpp")
+install(FILES ${HEADERS} DESTINATION include/tensor)
+
+## install libraries to the "lib" directory
+install(TARGETS tensor DESTINATION lib)

--- a/nuTens/tensors/CMakeLists.txt
+++ b/nuTens/tensors/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 if(NT_USE_TORCH)
-    add_library(tensor SHARED tensor.hpp torch-tensor.cpp)
+    add_library(tensor tensor.hpp torch-tensor.cpp)
     target_compile_definitions(tensor PUBLIC USE_PYTORCH)
 endif()
 

--- a/nuTens/tensors/CMakeLists.txt
+++ b/nuTens/tensors/CMakeLists.txt
@@ -18,4 +18,8 @@ set(HEADERS "tensor.hpp")
 install(FILES ${HEADERS} DESTINATION include/tensor)
 
 ## install libraries to the "lib" directory
-install(TARGETS tensor DESTINATION lib)
+install(
+    TARGETS tensor 
+    DESTINATION lib
+    EXPORT nuTens-targets
+)

--- a/nuTens/tensors/CMakeLists.txt
+++ b/nuTens/tensors/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 if(NT_USE_TORCH)
-    add_library(tensor STATIC tensor.hpp torch-tensor.cpp)
+    add_library(tensor SHARED tensor.hpp torch-tensor.cpp)
     target_compile_definitions(tensor PUBLIC USE_PYTORCH)
 endif()
 

--- a/nuTens/tensors/CMakeLists.txt
+++ b/nuTens/tensors/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-if(TORCH_FOUND)
+if(Torch_FOUND)
     add_library(tensor STATIC tensor.hpp torch-tensor.cpp)
     target_compile_definitions(tensor PUBLIC USE_PYTORCH)
 endif()

--- a/nuTens/utils/CMakeLists.txt
+++ b/nuTens/utils/CMakeLists.txt
@@ -2,9 +2,9 @@
 ########################
 #### set up logging ####
 ########################
-add_library(logging logging.hpp)
-target_link_libraries(logging spdlog::spdlog)
-set_target_properties(logging PROPERTIES LINKER_LANGUAGE CXX)
+add_library(nt-logging logging.hpp)
+target_link_libraries(nt-logging spdlog::spdlog)
+set_target_properties(nt-logging PROPERTIES LINKER_LANGUAGE CXX)
 
 ## get the log level specified by the user via -DNT_LOG_LEVEL
 set( NT_LOG_LEVEL "INFO" CACHE STRING "the level of detail to log to the console" )
@@ -22,7 +22,7 @@ else()
 endif()
 
 ## set the log level that will be used inside the logging.hpp file
-target_compile_definitions(logging PUBLIC NT_LOG_LEVEL=NT_LOG_LEVEL_${LOG_LEVEL_UPPER})
+target_compile_definitions(nt-logging PUBLIC NT_LOG_LEVEL=NT_LOG_LEVEL_${LOG_LEVEL_UPPER})
 
 
 ################################
@@ -42,7 +42,7 @@ endif()
 ################################
 add_library(tensor-backend INTERFACE)
 
-if(TORCH_FOUND)
+if(Torch_FOUND)
     target_link_libraries(tensor-backend INTERFACE "${TORCH_LIBRARIES}")
 else()
     message( FATAL_ERROR "No library found to deal with tensors. Currently only pytorch is available, please install this and try again." )
@@ -62,10 +62,10 @@ if(NT_USE_PCH)
     add_library(nuTens-pch OBJECT ${CMAKE_CURRENT_BINARY_DIR}/nuTens-pch.cpp)
     target_include_directories(nuTens-pch PUBLIC "${CMAKE_SOURCE_DIR}")
     
-    set(PCH_LIBS "${PCH_LIBS};logging;instrumentation")
+    set(PCH_LIBS "${PCH_LIBS};nt-logging;instrumentation")
 
     ## the headers included in the PCH will (at some point) depend on which tensor library is being used
-    if(TORCH_FOUND)
+    if(Torch_FOUND)
         target_compile_definitions(nuTens-pch PUBLIC USE_PYTORCH)
         set(PCH_LIBS "${PCH_LIBS};${TORCH_LIBRARIES}")
     endif()
@@ -77,5 +77,5 @@ if(NT_USE_PCH)
 endif() ## end NT_USE_PCH block
 
 add_library(utils INTERFACE)
-target_link_libraries(utils INTERFACE logging instrumentation tensor-backend)
+target_link_libraries(utils INTERFACE nt-logging instrumentation tensor-backend)
 target_include_directories(utils INTERFACE "${CMAKE_SOURCE_DIR}")

--- a/nuTens/utils/CMakeLists.txt
+++ b/nuTens/utils/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 ################################
 add_library(tensor-backend INTERFACE)
 
-if(Torch_FOUND)
+if(NT_USE_TORCH)
     target_link_libraries(tensor-backend INTERFACE "${TORCH_LIBRARIES}")
 else()
     message( FATAL_ERROR "No library found to deal with tensors. Currently only pytorch is available, please install this and try again." )
@@ -65,7 +65,7 @@ if(NT_USE_PCH)
     set(PCH_LIBS "${PCH_LIBS};nt-logging;instrumentation")
 
     ## the headers included in the PCH will (at some point) depend on which tensor library is being used
-    if(Torch_FOUND)
+    if(NT_USE_TORCH)
         target_compile_definitions(nuTens-pch PUBLIC USE_PYTORCH)
         set(PCH_LIBS "${PCH_LIBS};${TORCH_LIBRARIES}")
     endif()
@@ -79,3 +79,10 @@ endif() ## end NT_USE_PCH block
 add_library(utils INTERFACE)
 target_link_libraries(utils INTERFACE nt-logging instrumentation tensor-backend)
 target_include_directories(utils INTERFACE "${CMAKE_SOURCE_DIR}")
+
+## install headers to "include" directory
+set(HEADERS "instrumentation.hpp")
+install(FILES ${HEADERS} DESTINATION include/utils)
+
+## install libraries to the "lib" directory
+install(TARGETS instrumentation DESTINATION lib)

--- a/nuTens/utils/CMakeLists.txt
+++ b/nuTens/utils/CMakeLists.txt
@@ -2,8 +2,9 @@
 ########################
 #### set up logging ####
 ########################
-add_library(nt-logging logging.hpp)
-target_link_libraries(nt-logging spdlog::spdlog)
+add_library(nt-logging SHARED logging.hpp)
+target_link_libraries(nt-logging PRIVATE spdlog)
+target_include_directories(nt-logging PUBLIC ${spdlog_SOURCE_DIR}/include)
 set_target_properties(nt-logging PROPERTIES LINKER_LANGUAGE CXX)
 
 ## get the log level specified by the user via -DNT_LOG_LEVEL
@@ -78,11 +79,18 @@ endif() ## end NT_USE_PCH block
 
 add_library(utils INTERFACE)
 target_link_libraries(utils INTERFACE nt-logging instrumentation tensor-backend)
-target_include_directories(utils INTERFACE "${CMAKE_SOURCE_DIR}")
+target_include_directories(utils INTERFACE 
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
 
 ## install headers to "include" directory
 set(HEADERS "instrumentation.hpp")
 install(FILES ${HEADERS} DESTINATION include/utils)
 
 ## install libraries to the "lib" directory
-install(TARGETS instrumentation DESTINATION lib)
+install(
+    TARGETS nt-logging tensor-backend instrumentation utils
+    DESTINATION lib
+    EXPORT nuTens-targets
+)

--- a/nuTens/utils/CMakeLists.txt
+++ b/nuTens/utils/CMakeLists.txt
@@ -4,7 +4,12 @@
 ########################
 add_library(nt-logging SHARED logging.hpp)
 target_link_libraries(nt-logging PRIVATE spdlog)
-target_include_directories(nt-logging PUBLIC ${spdlog_SOURCE_DIR}/include)
+target_include_directories(nt-logging
+                           PUBLIC
+                            $<BUILD_INTERFACE:${spdlog_SOURCE_DIR}/include>
+                            $<INSTALL_INTERFACE:include>
+                           )
+
 set_target_properties(nt-logging PROPERTIES LINKER_LANGUAGE CXX)
 
 ## get the log level specified by the user via -DNT_LOG_LEVEL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ build-backend = "scikit_build_core.build"
 build-frontend = "build[uv]"
 
 [tool.scikit-build.cmake]
-args = ["-DNT_ENABLE_PYTHON=ON"]
+args = ["-DNT_ENABLE_PYTHON=ON -DBUILD_SHARED_LIBS=OFF"]
 
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.setuptools_scm"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ build-backend = "scikit_build_core.build"
 build-frontend = "build[uv]"
 
 [tool.scikit-build.cmake]
-args = ["-DNT_ENABLE_PYTHON=ON -DBUILD_SHARED_LIBS=OFF"]
+args = ["-DNT_ENABLE_PYTHON=ON", "-DBUILD_SHARED_LIBS=OFF"]
 
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.setuptools_scm"


### PR DESCRIPTION
nuTens can now (hopefully) be included as a package in another cmake project.

Can now also install pytorch within the cmake configuration step if user doesn't already have it installed - should make including in external projects easier.

added more options to configure how pytorch gets built

move to shared libraries instead of static