### PR TITLE
Remove all the faff from Pytorch_requirements.txt

### DIFF
--- a/PyTorch_requirements.txt
+++ b/PyTorch_requirements.txt
@@ -1,23 +1,5 @@
-attrs==23.2.0
-filelock==3.15.4
-gcovr==7.2
-jinja2==3.1.4
-jsonschema-specifications==2023.12.1
-MarkupSafe==2.1.3
-mpmath==1.3.0
-networkx==3.2.1
-platformdirs==4.2.2
-pyzmq==25.1.1
-referencing==0.35.1
-rpds-py==0.10.0
-six==1.16.0
-sympy==1.12.1
 numpy
+matplotlib
 
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==2.0.1+cpu
-
-tornado==6.3.3
-traitlets==5.14.3
-typing-extensions==4.12.2
-zipp==3.19.2
+torch==2.0.1+cpu.cxx11.abi


### PR DESCRIPTION
I think that this was just a dump of all used modules from early on.