### PR TITLE
CMAKE_SOURCE_DIR -> PROJECT_SOURCE_DIR

### DIFF
--- a/cmake/nuTens-dependencies.cmake
+++ b/cmake/nuTens-dependencies.cmake
@@ -32,11 +32,11 @@ This is ill advised, but if you're sure that's what you want to do you can set t
         find_package(Python COMPONENTS Interpreter REQUIRED)
         
         ## install torch Python package using pip
-        execute_process(COMMAND ${Python_EXECUTABLE} -m pip install -r ${CMAKE_SOURCE_DIR}/PyTorch_requirements.txt)
+        execute_process(COMMAND ${Python_EXECUTABLE} -m pip install -r ${PROJECT_SOURCE_DIR}/PyTorch_requirements.txt)
         
         ## need to do some absolute tomfoolery to get the path to the torch shared library
         execute_process(
-            COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/cmake/torch-cmake-prefix.py
+            COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/cmake/torch-cmake-prefix.py
             OUTPUT_VARIABLE _TORCH_CMAKE_PREFIX
         )
         string(REPLACE ' "" TORCH_CMAKE_PREFIX ${_TORCH_CMAKE_PREFIX})

--- a/nuTens/propagator/CMakeLists.txt
+++ b/nuTens/propagator/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NT_USE_PCH)
 endif()
 
 target_include_directories(propagator PUBLIC 
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include>
 )
 

--- a/nuTens/utils/CMakeLists.txt
+++ b/nuTens/utils/CMakeLists.txt
@@ -66,7 +66,7 @@ if(NT_USE_PCH)
     )
 
     add_library(nuTens-pch OBJECT ${CMAKE_CURRENT_BINARY_DIR}/nuTens-pch.cpp)
-    target_include_directories(nuTens-pch PUBLIC "${CMAKE_SOURCE_DIR}")
+    target_include_directories(nuTens-pch PUBLIC "${PROJECT_SOURCE_DIR}")
     
     set(PCH_LIBS "${PCH_LIBS};nt-logging;instrumentation")
 
@@ -85,7 +85,7 @@ endif() ## end NT_USE_PCH block
 add_library(utils INTERFACE)
 target_link_libraries(utils INTERFACE nt-logging instrumentation tensor-backend)
 target_include_directories(utils INTERFACE 
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include>
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ foreach(TESTNAME
     ENDIF()
 
     target_link_libraries("${TESTNAME}" PUBLIC nuTens test-utils m)
-    target_include_directories("${TESTNAME}" PUBLIC "${CMAKE_SOURCE_DIR}")
+    target_include_directories("${TESTNAME}" PUBLIC "${PROJECT_SOURCE_DIR}")
     add_test(NAME "${TESTNAME}-test" COMMAND "${TESTNAME}")
 
 endforeach()


### PR DESCRIPTION
more generic way of referencing the projects source directory meaning that it is easier to install in other projects