### PR TITLE
move to more general PROJECT_* cmake locations instead of CMAKE_* ones

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,8 +111,8 @@ install(EXPORT nuTens-targets
 include(CMakePackageConfigHelpers)
 
 # generate the config file that includes the exports
-configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/templates/nuTensConfig.cmake.in
-  "${CMAKE_CURRENT_BINARY_DIR}/nuTensConfig.cmake"
+configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/templates/nuTensConfig.cmake.in
+  "${PROJECT_BINARY_DIR}/nuTensConfig.cmake"
   INSTALL_DESTINATION "lib/cmake/nuTens"
   NO_SET_AND_CHECK_MACRO
   NO_CHECK_REQUIRED_COMPONENTS_MACRO
@@ -128,7 +128,7 @@ install(FILES
   DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/nuTens)
   
  export(EXPORT nuTens-targets
-  FILE "${CMAKE_CURRENT_BINARY_DIR}/nuTensTargets.cmake"
+  FILE "${PROJECT_BINARY_DIR}/nuTensTargets.cmake"
 )
 
 include(cmake/nuTens-config.cmake)

--- a/nuTens/CMakeLists.txt
+++ b/nuTens/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(nuTens INTERFACE tensor propagator)
 
 target_include_directories(nuTens
                            INTERFACE
-                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                            $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
                             $<INSTALL_INTERFACE:include>
                            )
 

--- a/nuTens/propagator/CMakeLists.txt
+++ b/nuTens/propagator/CMakeLists.txt
@@ -12,11 +12,13 @@ add_library(
 )
 
 target_link_libraries(
-    propagator PUBLIC 
+    propagator PRIVATE
     tensor 
     constants 
-    units 
-    utils
+    units
+    nt-logging
+    instrumentation
+    tensor-backend
     )
 
 if(NT_USE_PCH)

--- a/nuTens/tensors/CMakeLists.txt
+++ b/nuTens/tensors/CMakeLists.txt
@@ -1,12 +1,12 @@
 
 if(NT_USE_TORCH)
-    add_library(tensor tensor.hpp torch-tensor.cpp)
+    add_library(tensor tensor.hpp torch-tensor.cpp dtypes.hpp)
     target_compile_definitions(tensor PUBLIC USE_PYTORCH)
 endif()
 
 target_include_directories(tensor
                            PUBLIC
-                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../>
+                            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
                             $<INSTALL_INTERFACE:include>
                            )
 
@@ -16,7 +16,12 @@ if(NT_USE_PCH)
     target_precompile_headers(tensor REUSE_FROM nuTens-pch)
 endif()
 
-target_link_libraries(tensor PUBLIC utils)
+target_link_libraries(
+    tensor PUBLIC
+    nt-logging
+    instrumentation
+    tensor-backend)
+
 set_target_properties(tensor PROPERTIES LINKER_LANGUAGE CXX)
 
 ## install headers to "include" directory

--- a/nuTens/utils/CMakeLists.txt
+++ b/nuTens/utils/CMakeLists.txt
@@ -61,11 +61,11 @@ if(NT_USE_PCH)
     message("Using precompiled header")
     
     file(GENERATE
-        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/nuTens-pch.cpp
+        OUTPUT ${PROJECT_BINARY_DIR}/utils/nuTens-pch.cpp
         CONTENT ""
     )
 
-    add_library(nuTens-pch OBJECT ${CMAKE_CURRENT_BINARY_DIR}/nuTens-pch.cpp)
+    add_library(nuTens-pch OBJECT ${PROJECT_BINARY_DIR}/utils/nuTens-pch.cpp)
     target_include_directories(nuTens-pch PUBLIC "${PROJECT_SOURCE_DIR}")
     
     set(PCH_LIBS "${PCH_LIBS};nt-logging;instrumentation")
@@ -82,20 +82,13 @@ if(NT_USE_PCH)
 
 endif() ## end NT_USE_PCH block
 
-add_library(utils INTERFACE)
-target_link_libraries(utils INTERFACE nt-logging instrumentation tensor-backend)
-target_include_directories(utils INTERFACE 
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:include>
-)
-
 ## install headers to "include" directory
 set(HEADERS "instrumentation.hpp")
 install(FILES ${HEADERS} DESTINATION include/utils)
 
 ## install libraries to the "lib" directory
 install(
-    TARGETS nt-logging tensor-backend instrumentation utils
+    TARGETS instrumentation nt-logging tensor-backend
     DESTINATION lib
     EXPORT nuTens-targets
 )


### PR DESCRIPTION
should make inclusion in external projects smoother and no longer install things in weird places

also remove weird utils library that seemed to be complicating things