### PR TITLE
fix: setMatterSolver initialised variable assumption

### DIFF
--- a/benchmarks/benchmarks.cpp
+++ b/benchmarks/benchmarks.cpp
@@ -174,12 +174,13 @@ static void BM_constMatterOscillations(benchmark::State &state)
 
     // set up the propagator
     Propagator matterProp(3, 295000.0);
-    matterProp.setMixingMatrix(PMNS.matrix);
-    matterProp.setMasses(masses);
-
+    
     std::shared_ptr<BaseMatterSolver> matterSolver = std::make_shared<ConstDensityMatterSolver>(3, 2.6);
 
     matterProp.setMatterSolver(matterSolver);
+    matterProp.setMixingMatrix(PMNS.matrix);
+    matterProp.setMasses(masses);
+
 
     matterProp.setEnergies(energies);
 

--- a/examples/python/neutrino-anti-neutrino-comparison.py
+++ b/examples/python/neutrino-anti-neutrino-comparison.py
@@ -74,9 +74,9 @@ baseline = 295.0 * nt.units.km
 propagator = nt.propagator.Propagator(3, baseline)
 matter_solver = nt.propagator.ConstDensitySolver(3, 2.79)
 
+propagator.set_matter_solver(matter_solver)
 propagator.set_mixing_matrix(PMNS)
 propagator.set_masses(masses)
-propagator.set_matter_solver(matter_solver)
 
 ## run!
 propagator.set_energies(energies)

--- a/examples/python/three-flavour-vacuum.py
+++ b/examples/python/three-flavour-vacuum.py
@@ -79,11 +79,11 @@ print()
 propagator = nt.propagator.Propagator(3, 295.0 * nt.units.km)
 matter_solver = nt.propagator.ConstDensitySolver(3, 2.79)
 
-propagator.set_mixing_matrix(PMNS)
-propagator.set_masses(masses)
-
 ## uncomment for matter oscillations
 #propagator.set_matter_solver(matter_solver)
+
+propagator.set_mixing_matrix(PMNS)
+propagator.set_masses(masses)
 
 ## run!
 propagator.set_energies(energies)

--- a/examples/python/two-flavour-const-matter.py
+++ b/examples/python/two-flavour-const-matter.py
@@ -52,9 +52,9 @@ print()
 propagator = nt.propagator.Propagator(2, 295 * nt.units.km)
 matter_solver = nt.propagator.ConstDensitySolver(2, 2.79)
 
+propagator.set_matter_solver(matter_solver)
 propagator.set_mixing_matrix(PMNS)
 propagator.set_masses(masses)
-propagator.set_matter_solver(matter_solver)
 
 ## run!
 propagator.set_energies(energies)

--- a/nuTens/propagator/propagator.hpp
+++ b/nuTens/propagator/propagator.hpp
@@ -62,12 +62,11 @@ class Propagator
 
     /// @brief Set a matter solver to use to deal with matter effects
     /// @param newSolver A derivative of BaseMatterSolver
+    /// @warning Should be called *before* setMixingMatrix and setMasses
     inline void setMatterSolver(const std::shared_ptr<BaseMatterSolver> &newSolver)
     {
         NT_PROFILE();
         _matterSolver = newSolver;
-        _matterSolver->setMasses(_masses);
-        _matterSolver->setMixingMatrix(_mixingMatrix);
     }
 
     /// \todo Should add a check to tensors supplied to the setters to see how

--- a/tests/python/test_two-flavour-const-matter.py
+++ b/tests/python/test_two-flavour-const-matter.py
@@ -95,9 +95,9 @@ class TestTwoFlavourConstMatter:
         propagator = nt.propagator.Propagator(2, self.baseline)
         matter_solver = ConstDensitySolver(2, self.density)
         
+        propagator.set_matter_solver(matter_solver)
         propagator.set_mixing_matrix(pmns)
         propagator.set_masses(masses)
-        propagator.set_matter_solver(matter_solver)
         propagator.set_energies(self.energy_tensor)
 
         # calculate the evals + evecs + effective PMNS to print 

--- a/tests/two-flavour-const-matter-anti-nu.cpp
+++ b/tests/two-flavour-const-matter-anti-nu.cpp
@@ -58,9 +58,9 @@ int main()
         PMNS.setValue({0, 1, 0}, -std::sin(theta));
         PMNS.setValue({0, 1, 1}, std::cos(theta));
 
+        tensorPropagator.setMatterSolver(tensorSolver);
         tensorPropagator.setMixingMatrix(PMNS);
         tensorPropagator.setMasses(masses);
-        tensorPropagator.setMatterSolver(tensorSolver);
         tensorPropagator.setAntiNeutrino(true);
 
         tensorPropagator.setEnergies(energies);

--- a/tests/two-flavour-const-matter.cpp
+++ b/tests/two-flavour-const-matter.cpp
@@ -47,9 +47,9 @@ int main()
         PMNS.setValue({0, 1, 1}, std::cos(theta));
         PMNS.requiresGrad(true);
 
+        tensorPropagator.setMatterSolver(tensorSolver);
         tensorPropagator.setMixingMatrix(PMNS);
         tensorPropagator.setMasses(masses);
-        tensorPropagator.setMatterSolver(tensorSolver);
 
         tensorPropagator.setEnergies(energies);
 


### PR DESCRIPTION
 remove assumption that mixing matrix and masses are already set when adding matter solver to propagator

closes #97 