### PR TITLE
Fix Groot2 extra factor of 2

### DIFF
--- a/nuTens/propagator/constants.hpp
+++ b/nuTens/propagator/constants.hpp
@@ -11,7 +11,7 @@ namespace nuTens
 namespace constants
 {
 
-    static constexpr float Groot2 = 1.52588e-4 * (units::eV * units::eV) / units::GeV; //!< sqrt(2)*G_fermi in (eV^2-cm^3)/(mole-GeV) used in calculating matter hamiltonian
+    static constexpr double Groot2 = 0.76294e-4 * (units::eV * units::eV) / units::GeV; //!< sqrt(2)*G_fermi in (eV^2-cm^3)/(mole-GeV) used in calculating matter hamiltonian
 
 }
 

--- a/nuTens/propagator/units.hpp
+++ b/nuTens/propagator/units.hpp
@@ -17,7 +17,7 @@ namespace units
     static constexpr double MeV = 1e6; // eV
     static constexpr double GeV = 1e9; // eV
 
-    static constexpr double m = 5.0677302143e6; // eV^-1 
+    static constexpr double m = 5.07614213198e6; // eV^-1
     static constexpr double cm = 1e-2 * m; // eV^-1
     static constexpr double km = 1e3  * m; // eV^-1
 

--- a/nuTens/propagator/units.hpp
+++ b/nuTens/propagator/units.hpp
@@ -17,7 +17,7 @@ namespace units
     static constexpr double MeV = 1e6; // eV
     static constexpr double GeV = 1e9; // eV
 
-    static constexpr double m = 5.07614213198e6; // eV^-1 
+    static constexpr double m = 5.0677302143e6; // eV^-1 
     static constexpr double cm = 1e-2 * m; // eV^-1
     static constexpr double km = 1e3  * m; // eV^-1
 


### PR DESCRIPTION
had mistakenly included extra factor of 2 in Groot2 constant as it tends to be used in other oscillation engines. Removed this.

Breaks the externally calculated barger test but this will be fixed in following pr