### PR TITLE
Fix - minor: eigval eigvec arg ordering

### DIFF
--- a/nuTens/propagator/const-density-solver.cpp
+++ b/nuTens/propagator/const-density-solver.cpp
@@ -16,7 +16,7 @@ void ConstDensityMatterSolver::calculateEigenvalues(Tensor &eigenvectors, Tensor
         }
     }
 
-    Tensor::eigh(hamiltonian, eigenvectors, eigenvalues);
+    Tensor::eigh(hamiltonian, eigenvalues, eigenvectors);
 }
 
 void ConstDensityMatterSolver::buildElectronOuterProduct() 

--- a/nuTens/tensors/torch-tensor.cpp
+++ b/nuTens/tensors/torch-tensor.cpp
@@ -434,8 +434,8 @@ void Tensor::eig(const Tensor &t, Tensor &eVals, Tensor &eVecs)
     NT_PROFILE();
 
     auto ret = torch::linalg_eig(t._tensor);
-    eVals.setTensor(std::get<1>(ret));
-    eVecs.setTensor(std::get<0>(ret));
+    eVals.setTensor(std::get<0>(ret));
+    eVecs.setTensor(std::get<1>(ret));
 }
 
 void Tensor::eigh(const Tensor &t, Tensor &eVals, Tensor &eVecs)
@@ -443,8 +443,8 @@ void Tensor::eigh(const Tensor &t, Tensor &eVals, Tensor &eVecs)
     NT_PROFILE();
 
     auto ret = torch::linalg_eigh(t._tensor);
-    eVals.setTensor(std::get<1>(ret));
-    eVecs.setTensor(std::get<0>(ret));
+    eVals.setTensor(std::get<0>(ret));
+    eVecs.setTensor(std::get<1>(ret));
 }
 
 void Tensor::eigvals(const Tensor &t, Tensor &eVals)


### PR DESCRIPTION
Ordering of evals and evecs was wrong in eig and eigh functions. However was cancelled out by them also being in the wrong order in the one place this function was called so it all worked out fine. best to be correct tho