### PR TITLE
fix the order of the conjugation when constructing the electron row outer product

### DIFF
--- a/nuTens/propagator/const-density-solver.cpp
+++ b/nuTens/propagator/const-density-solver.cpp
@@ -48,14 +48,14 @@ void ConstDensityMatterSolver::buildElectronOuterProduct()
     if (antiNeutrino)
     {
         electronOuter =
-            Tensor::scale(Tensor::outer(mixingMatrix.getValues({0, 0, "..."}).conj(), mixingMatrix.getValues({0, 0, "..."})),
+            Tensor::scale(Tensor::outer(mixingMatrix.getValues({0, 0, "..."}), mixingMatrix.getValues({0, 0, "..."}).conj()),
                           -nuTens::constants::Groot2 * density);
     }
 
     else 
     {
         electronOuter =
-            Tensor::scale(Tensor::outer(mixingMatrix.getValues({0, 0, "..."}), mixingMatrix.getValues({0, 0, "..."}).conj()),
+            Tensor::scale(Tensor::outer(mixingMatrix.getValues({0, 0, "..."}).conj(), mixingMatrix.getValues({0, 0, "..."})),
                           nuTens::constants::Groot2 * density);
     }
 


### PR DESCRIPTION
Looking more carefully at eq 5 in Barger et al, the conjugation should be swapped when building the electon row outer product

<img width="701" height="146" alt="image" src="https://github.com/user-attachments/assets/2fcd7fae-5f0a-46ce-9c85-f5fb034ddfe6" />
