### PR TITLE
Fix conjugation for antineutrinos in ConstDensitySolver

### DIFF
--- a/nuTens/propagator/const-density-solver.cpp
+++ b/nuTens/propagator/const-density-solver.cpp
@@ -48,7 +48,7 @@ void ConstDensityMatterSolver::buildElectronOuterProduct()
     if (antiNeutrino)
     {
         electronOuter =
-            Tensor::scale(Tensor::outer(mixingMatrix.getValues({0, 0, "..."}), mixingMatrix.getValues({0, 0, "..."}).conj()),
+            Tensor::scale(Tensor::outer(mixingMatrix.getValues({0, 0, "..."}).conj(), mixingMatrix.getValues({0, 0, "..."})),
                           -nuTens::constants::Groot2 * density);
     }
 

--- a/tests/barger-propagator.hpp
+++ b/tests/barger-propagator.hpp
@@ -232,10 +232,10 @@ class ThreeFlavourBarger
         pmnsMatrix[0][2] = std::sin(theta13) * std::exp(std::complex<double>(0.0, -1.0) * deltaCP);
 
         pmnsMatrix[1][0] = -std::sin(theta12) * std::cos(theta23) - std::cos(theta12) * std::sin(theta23) * std::sin(theta13) * std::exp(std::complex<double>(0.0, 1.0) * deltaCP);
-        pmnsMatrix[1][1] = std::cos(theta12) * std::cos(theta23) - std::sin(theta12) * std::sin(theta23) * std::sin(theta13) * std::exp(std::complex<double>(0.0, 1.0) * deltaCP);
+        pmnsMatrix[1][1] = std::cos(theta12) * std::cos(theta23)  - std::sin(theta12) * std::sin(theta23) * std::sin(theta13) * std::exp(std::complex<double>(0.0, 1.0) * deltaCP);
         pmnsMatrix[1][2] = std::complex<double>(std::sin(theta23) * std::cos(theta13), 0.0);
 
-        pmnsMatrix[2][0] = std::sin(theta12) * std::sin(theta23) - std::cos(theta12) * std::cos(theta23) * std::sin(theta13) * std::exp(std::complex<double>(0.0, 1.0) * deltaCP);
+        pmnsMatrix[2][0] = std::sin(theta12) * std::sin(theta23)  - std::cos(theta12) * std::cos(theta23) * std::sin(theta13) * std::exp(std::complex<double>(0.0, 1.0) * deltaCP);
         pmnsMatrix[2][1] = -std::cos(theta12) * std::sin(theta23) - std::sin(theta12) * std::cos(theta23) * std::sin(theta13) * std::exp(std::complex<double>(0.0, 1.0) * deltaCP);
         pmnsMatrix[2][2] = std::complex<double>(std::cos(theta23) * std::cos(theta13), 0.0);
 
@@ -338,7 +338,7 @@ class ThreeFlavourBarger
         }
 
         if (_antiNeutrino) {
-            ret += constants::Groot2 * _density * std::conj(pmnsMatrix[0][b]) * pmnsMatrix[0][a];
+            ret += constants::Groot2 * _density * pmnsMatrix[0][b] * std::conj(pmnsMatrix[0][a]);
         }
         else {
             ret -= constants::Groot2 * _density * pmnsMatrix[0][b] * std::conj(pmnsMatrix[0][a]);


### PR DESCRIPTION
switch conjugation order for electron neutrino outer product in line with other oscillation engines

this seems to not be in line with what is written in the barger paper, but is in line with what is done in other oscillation engines.... maybe i need to investigate more