### PR TITLE
Use setters for propagation classes

### DIFF
--- a/benchmarks/benchmarks.cpp
+++ b/benchmarks/benchmarks.cpp
@@ -80,7 +80,7 @@ static void BM_vacuumOscillations(benchmark::State &state)
     PMNSmatrix PMNS;
 
     // set up the propagator
-    Propagator vacuumProp(3, baseline);
+    Propagator vacuumProp = Propagator(3).setBaseline(baseline);
     vacuumProp.setEnergies(energies);
 
     // seed the random number generator for the energies
@@ -116,7 +116,7 @@ static void BM_constMatterOscillations(benchmark::State &state)
     PMNSmatrix PMNS;
 
     // set up the propagator
-    Propagator matterProp(3, baseline);
+    Propagator matterProp = Propagator(3).setBaseline(baseline);
     auto matterSolver = std::make_shared<ConstDensityMatterSolver>(3);
     matterSolver->setDensity(density);
     matterProp.setMatterSolver(matterSolver);

--- a/benchmarks/benchmarks.cpp
+++ b/benchmarks/benchmarks.cpp
@@ -118,7 +118,8 @@ static void BM_constMatterOscillations(benchmark::State &state)
 
     // set up the propagator
     Propagator matterProp(3, baseline);
-    auto matterSolver = std::make_shared<ConstDensityMatterSolver>(3, density);
+    auto matterSolver = std::make_shared<ConstDensityMatterSolver>(3);
+    matterSolver->setDensity(density);
     matterProp.setMatterSolver(matterSolver);
     matterProp.setEnergies(energies);
 

--- a/benchmarks/benchmarks.cpp
+++ b/benchmarks/benchmarks.cpp
@@ -47,11 +47,10 @@ static void batchedOscProbs(Propagator &prop, PMNSmatrix &matrix, AccessedTensor
         masses.setValue(randomDouble(), 0, 1);
         masses.setValue(randomDouble(), 0, 2);
 
-        matrix.setParameterValues(
-            /*theta12=*/randomFloat(),
-            /*theta13=*/randomFloat(),
-            /*theta23=*/randomFloat(),
-            /*deltaCP=*/randomFloat() * (float)constants::twoPi);
+        matrix.setTheta12(randomFloat())
+            .setTheta13(randomFloat())
+            .setTheta23(randomFloat())
+            .setDeltaCP(randomFloat() * (float)constants::twoPi);
 
         prop.setMixingMatrix(matrix.build());
         prop.setMasses(masses);

--- a/nuTens/propagator/DP-propagator.hpp
+++ b/nuTens/propagator/DP-propagator.hpp
@@ -138,11 +138,13 @@ class DPpropagator : public Propagator
 
     /// @brief Set the neutrino energies
     /// @param newEnergies The neutrino energies
-    inline void setEnergies(Tensor &newEnergies) override
+    inline DPpropagator &setEnergies(Tensor &newEnergies) override
     {
         NT_PROFILE();
 
         _energies = newEnergies;
+
+        return *this;
     }
 
     /// @}

--- a/nuTens/propagator/base-matter-solver.hpp
+++ b/nuTens/propagator/base-matter-solver.hpp
@@ -34,26 +34,28 @@ class BaseMatterSolver
 
     /// @brief Set a new mixing matrix for this solver
     /// @param newMatrix The new matrix to set
-    virtual inline void setMixingMatrix(const Tensor &newMatrix)
+    virtual inline BaseMatterSolver &setMixingMatrix(const Tensor &newMatrix)
     {
         NT_PROFILE();
 
         mixingMatrix = newMatrix;
+
+        return *this;
     }
 
     /// @brief Set new mass eigenvalues for this solver
     /// @param newMasses The new masses
-    virtual inline void setMasses(const Tensor &newMasses)
+    virtual inline BaseMatterSolver &setMasses(const Tensor &newMasses)
     {
         assert((newMasses.getNdim() == 2));
         NT_PROFILE();
 
         masses = newMasses;
+
+        return *this;
     }
 
-    virtual void calculateEigenvalues(Tensor &eigenvectors, Tensor &eigenvalues) = 0;
-
-    inline virtual void setEnergies(const Tensor &newEnergies)
+    inline virtual BaseMatterSolver &setEnergies(const Tensor &newEnergies)
     {
 
         assert((newEnergies.getNdim() == 2));
@@ -66,18 +68,24 @@ class BaseMatterSolver
 
         hamiltonian = Tensor::zeros({energies.getBatchDim(), nGenerations, nGenerations}, dtypes::kComplexFloat)
                           .requiresGrad(false);
+
+        return *this;
     }
 
     /// @brief Set whether we are dealing with anti-neutrinos
     /// @param newValue
-    virtual inline void setAntiNeutrino(bool newValue)
+    virtual inline BaseMatterSolver &setAntiNeutrino(bool newValue)
     {
         NT_PROFILE();
 
         antiNeutrino = newValue;
+
+        return *this;
     }
 
     /// @}
+
+    virtual void calculateEigenvalues(Tensor &eigenvectors, Tensor &eigenvalues) = 0;
 
   protected:
     bool antiNeutrino;

--- a/nuTens/propagator/const-density-solver.cpp
+++ b/nuTens/propagator/const-density-solver.cpp
@@ -16,6 +16,8 @@ void ConstDensityMatterSolver::buildHamiltonian()
 
     NT_PROFILE();
 
+    buildElectronOuterProduct();
+
     hamiltonian.setValue({"..."}, (Tensor::div(diagMassMatrix, energiesRed) - electronOuter));
 }
 

--- a/nuTens/propagator/const-density-solver.hpp
+++ b/nuTens/propagator/const-density-solver.hpp
@@ -36,16 +36,13 @@ class ConstDensityMatterSolver : public BaseMatterSolver
     /// @brief Constructor
     /// @arg nGenerations The number of neutrino generations this propagator
     /// should expect
-    /// @arg density The electron density of the material to propagate in
-    /// @arg antiNeutrino True if we are calculating effects for anti-neutrinos
-    ConstDensityMatterSolver(int nGenerations, float density, bool antiNeutrino = false)
-        : BaseMatterSolver(nGenerations, antiNeutrino), density(density)
+    ConstDensityMatterSolver(int nGenerations) : BaseMatterSolver(nGenerations, false)
     {
         diagMassMatrix = Tensor::zeros({1, nGenerations, nGenerations}, dtypes::kComplexFloat).requiresGrad(false);
     };
 
     /// @brief destructor
-    virtual ~ConstDensityMatterSolver() = default;
+    virtual ~ConstDensityMatterSolver() override = default;
     /// @brief copy constructor
     ConstDensityMatterSolver(ConstDensityMatterSolver const &) = default;
     /// @brief copy assignment operator
@@ -60,29 +57,29 @@ class ConstDensityMatterSolver : public BaseMatterSolver
 
     /// @brief Set whether we are dealing with anti-neutrinos
     /// @param newValue
-    inline void setAntiNeutrino(bool newValue) override
+    inline ConstDensityMatterSolver &setAntiNeutrino(bool newValue) override
     {
         NT_PROFILE();
 
         BaseMatterSolver::setAntiNeutrino(newValue);
 
-        buildElectronOuterProduct();
+        return *this;
     }
 
     /// @brief Set a new mixing matrix for this solver
     /// @param newMatrix The new matrix to set
-    inline void setMixingMatrix(const Tensor &newMatrix) override
+    inline ConstDensityMatterSolver &setMixingMatrix(const Tensor &newMatrix) override
     {
         NT_PROFILE();
 
         mixingMatrix = newMatrix;
 
-        buildElectronOuterProduct();
+        return *this;
     };
 
     /// @brief Set new mass eigenvalues for this solver
     /// @param newMasses The new masses
-    inline void setMasses(const Tensor &newMasses) override
+    inline ConstDensityMatterSolver &setMasses(const Tensor &newMasses) override
     {
         assert((newMasses.getNdim() == 2));
         NT_PROFILE();
@@ -94,11 +91,13 @@ class ConstDensityMatterSolver : public BaseMatterSolver
 
         // construct the diagonal mass^2 matrix used in the hamiltonian
         diagMassMatrix = Tensor::diag(diag).requiresGrad(false).unsqueeze(0);
+
+        return *this;
     }
 
     /// @brief set a new density
     /// @param newDensity the new value
-    inline void setDensity(float newDensity)
+    inline ConstDensityMatterSolver &setDensity(float newDensity)
     {
         /// @todo super inefficient to recalculate this here and also in
         /// setMixingMatrix. Would be good to have some _valuesChanged flag that causes
@@ -110,7 +109,7 @@ class ConstDensityMatterSolver : public BaseMatterSolver
 
         density = newDensity;
 
-        buildElectronOuterProduct();
+        return *this;
     }
 
     /// @}
@@ -130,11 +129,11 @@ class ConstDensityMatterSolver : public BaseMatterSolver
 
     /// construct the outer product of the electron row of the mixing matrix, used in building the hamiltonian, and
     /// return a copy of it potentially useful for debugging
-    Tensor getElectronOuterProduct();
+    [[nodiscard]] Tensor getElectronOuterProduct();
 
     /// construct the hamiltonian and return a copy of it
     /// potentially useful for debugging
-    Tensor getHamiltonian();
+    [[nodiscard]] Tensor getHamiltonian();
 
   private:
     /// @brief construct the outer product of the electron neutrino row of the mixing
@@ -146,7 +145,7 @@ class ConstDensityMatterSolver : public BaseMatterSolver
 
     Tensor diagMassMatrix;
     Tensor electronOuter;
-    float density;
+    float density{NAN};
 };
 
 }; // namespace nuTens

--- a/nuTens/propagator/const-density-solver.hpp
+++ b/nuTens/propagator/const-density-solver.hpp
@@ -42,7 +42,7 @@ class ConstDensityMatterSolver : public BaseMatterSolver
     };
 
     /// @brief destructor
-    virtual ~ConstDensityMatterSolver() override = default;
+    ~ConstDensityMatterSolver() override = default;
     /// @brief copy constructor
     ConstDensityMatterSolver(ConstDensityMatterSolver const &) = default;
     /// @brief copy assignment operator

--- a/nuTens/propagator/pmns-matrix.hpp
+++ b/nuTens/propagator/pmns-matrix.hpp
@@ -23,27 +23,68 @@ class PMNSmatrix : public BaseMixingMatrix
         _mat3 = Tensor::zeros({1, 3, 3}, dtypes::kComplexFloat).requiresGrad(false);
     }
 
-    inline void setParameterValues(float theta12, float theta13, float theta23, float deltaCP)
+    inline PMNSmatrix &setTheta12(float theta12)
     {
         NT_PROFILE();
 
         _theta12.requiresGrad(false);
-        _theta13.requiresGrad(false);
-        _theta23.requiresGrad(false);
-        _deltaCP.requiresGrad(false);
 
         _theta12.setValue(theta12, 0);
-        _theta13.setValue(theta13, 0);
-        _theta23.setValue(theta23, 0);
-        _deltaCP.setValue({0}, deltaCP);
 
         _theta12.requiresGrad(true);
+
+        // set the dirty flag
+        _needsRecalculating = true;
+
+        return *this;
+    }
+
+    inline PMNSmatrix &setTheta13(float theta13)
+    {
+        NT_PROFILE();
+
+        _theta13.requiresGrad(false);
+
+        _theta13.setValue(theta13, 0);
+
         _theta13.requiresGrad(true);
+
+        // set the dirty flag
+        _needsRecalculating = true;
+
+        return *this;
+    }
+
+    inline PMNSmatrix &setTheta23(float theta23)
+    {
+        NT_PROFILE();
+
+        _theta23.requiresGrad(false);
+
+        _theta23.setValue(theta23, 0);
+
         _theta23.requiresGrad(true);
+
+        // set the dirty flag
+        _needsRecalculating = true;
+
+        return *this;
+    }
+
+    inline PMNSmatrix &setDeltaCP(float deltaCP)
+    {
+        NT_PROFILE();
+
+        _deltaCP.requiresGrad(false);
+
+        _deltaCP.setValue({0}, deltaCP);
+
         _deltaCP.requiresGrad(true);
 
         // set the dirty flag
         _needsRecalculating = true;
+
+        return *this;
     }
 
     /// @{Setters

--- a/nuTens/propagator/propagator.hpp
+++ b/nuTens/propagator/propagator.hpp
@@ -93,10 +93,20 @@ class Propagator
         NT_PROFILE();
         _matterSolver = newSolver;
 
-        _matterSolver->setEnergies(_energies);
-        _matterSolver->setMasses(_masses);
+        if (_energiesInitialised)
+        {
+            _matterSolver->setEnergies(_energies);
+        }
+
+        if (_massesInitialised)
+        {
+            _matterSolver->setMasses(_masses);
+        }
+        if (_mixingMatrixInitialised)
+        {
+            _matterSolver->setMixingMatrix(_mixingMatrix);
+        }
         _matterSolver->setAntiNeutrino(_antiNeutrino);
-        _matterSolver->setMixingMatrix(_mixingMatrix);
 
         return *this;
     }
@@ -111,6 +121,8 @@ class Propagator
         NT_PROFILE();
 
         _energies = newEnergies;
+        _energiesInitialised = true;
+
         _weightMatrix = Tensor::ones({_energies.getBatchDim(), _nGenerations, _nGenerations}, dtypes::kComplexFloat)
                             .requiresGrad(false);
 
@@ -133,7 +145,9 @@ class Propagator
         NT_PROFILE();
 
         _masses = newMasses;
-        if (_matterSolver != nullptr)
+        _massesInitialised = true;
+
+        if (_matterSolver)
         {
             _matterSolver->setMasses(newMasses);
         }
@@ -147,7 +161,9 @@ class Propagator
     {
         NT_PROFILE();
         _mixingMatrix = newMatrix;
-        if (_matterSolver != nullptr)
+        _mixingMatrixInitialised = true;
+
+        if (_matterSolver)
         {
             _matterSolver->setMixingMatrix(newMatrix);
         }
@@ -187,8 +203,16 @@ class Propagator
     Tensor _mixingMatrix;
     Tensor _masses;
     Tensor _energies;
+
+    // flags to keep track of which tensors have been set by user
+    /// @todo could just have an "initialised" flag in tensor class to keep track of this in more general way
+    bool _mixingMatrixInitialised{false};
+    bool _massesInitialised{false};
+    bool _energiesInitialised{false};
+
     Tensor _weightMatrix;
     Tensor _weightArgDenom;
+
     int _nGenerations;
     float _baseline{NAN};
     bool _antiNeutrino{false};

--- a/nuTens/propagator/propagator.hpp
+++ b/nuTens/propagator/propagator.hpp
@@ -52,13 +52,6 @@ class Propagator
     /// expect
     Propagator(int nGenerations) : _nGenerations(nGenerations){};
 
-    /// @brief Constructor
-    /// @param nGenerations The number of generations the propagator should
-    /// expect
-    /// @param baseline The baseline to propagate over
-    Propagator(int nGenerations, float baseline, bool antiNeutrino = false)
-        : _baseline(baseline), _nGenerations(nGenerations), _antiNeutrino(antiNeutrino){};
-
     /// @brief Destructor
     virtual ~Propagator() = default;
     /// @brief copy constructor
@@ -79,7 +72,7 @@ class Propagator
 
     /// @brief Set whether we are dealing with anti-neutrinos
     /// @param newValue
-    inline void setAntiNeutrino(bool newValue)
+    inline Propagator &setAntiNeutrino(bool newValue)
     {
         NT_PROFILE();
 
@@ -89,15 +82,23 @@ class Propagator
         {
             _matterSolver->setAntiNeutrino(newValue);
         }
+
+        return *this;
     }
 
     /// @brief Set a matter solver to use to deal with matter effects
     /// @param newSolver A derivative of BaseMatterSolver
-    /// @warning Should be called *before* setMixingMatrix and setMasses
-    virtual inline void setMatterSolver(const std::shared_ptr<BaseMatterSolver> &newSolver)
+    virtual inline Propagator &setMatterSolver(const std::shared_ptr<BaseMatterSolver> &newSolver)
     {
         NT_PROFILE();
         _matterSolver = newSolver;
+
+        _matterSolver->setEnergies(_energies);
+        _matterSolver->setMasses(_masses);
+        _matterSolver->setAntiNeutrino(_antiNeutrino);
+        _matterSolver->setMixingMatrix(_mixingMatrix);
+
+        return *this;
     }
 
     /// \todo Should add a check to tensors supplied to the setters to see how
@@ -105,7 +106,7 @@ class Propagator
 
     /// @brief Set the neutrino energies
     /// @param newEnergies The neutrino energies
-    virtual void setEnergies(Tensor &newEnergies)
+    virtual Propagator &setEnergies(Tensor &newEnergies)
     {
         NT_PROFILE();
 
@@ -117,6 +118,8 @@ class Propagator
         {
             _matterSolver->setEnergies(newEnergies);
         }
+
+        return *this;
     }
 
     /// @brief Set the masses corresponding to the vacuum hamiltonian eigenstates
@@ -125,7 +128,7 @@ class Propagator
     /// dimension can (and probably should) be 1 and it will be broadcast to
     /// match the batch dimension of the energies supplied to calculateProbs().
     /// So dimension should be {1, nGenerations}.
-    virtual void setMasses(Tensor &newMasses)
+    virtual inline Propagator &setMasses(Tensor &newMasses)
     {
         NT_PROFILE();
 
@@ -134,11 +137,13 @@ class Propagator
         {
             _matterSolver->setMasses(newMasses);
         }
+
+        return *this;
     }
 
     /// @brief Set a whole new mixing matrix
     /// @param newMatrix The new matrix to use
-    virtual inline void setMixingMatrix(Tensor &newMatrix)
+    virtual inline Propagator &setMixingMatrix(Tensor &newMatrix)
     {
         NT_PROFILE();
         _mixingMatrix = newMatrix;
@@ -146,38 +151,20 @@ class Propagator
         {
             _matterSolver->setMixingMatrix(newMatrix);
         }
-    }
 
-    /// \todo add setMixingMatrix(const std::vector<int> &indices, float value) methods
-    /// to BaseMatterSolver? maybe have these setters in a base class of both
-    /// Propagator and BaseMatterSolver ??
-
-    /// @brief Set a single element of the mixing matrix
-    /// @param indices The index of the value to set
-    /// @param value The new value
-    inline void setMixingMatrix(const std::vector<int> &indices, float value)
-    {
-        NT_PROFILE();
-        _mixingMatrix.setValue(indices, value);
-    }
-
-    /// @brief Set a single element of the mixing matrix
-    /// @param indices The index of the value to set
-    /// @param value The new value
-    inline void setMixingMatrix(const std::vector<int> &indices, std::complex<float> value)
-    {
-        NT_PROFILE();
-        _mixingMatrix.setValue(indices, value);
+        return *this;
     }
 
     /// @brief Set the baseline
     /// @param newBaseline new value
-    inline void setBaseline(float newBaseline)
+    inline Propagator &setBaseline(float newBaseline)
     {
 
         NT_PROFILE();
 
         _baseline = newBaseline;
+
+        return *this;
     }
 
     /// @}

--- a/python/binding.cpp
+++ b/python/binding.cpp
@@ -510,14 +510,14 @@ void initPropagator(py::module &m_nuTens)
      py::class_<PMNSmatrix, std::shared_ptr<PMNSmatrix>, BaseMixingMatrix>(
         m_propagator, "PMNSmatrix")
         .def(py::init<>())
-        .def("set_theta_12", (&PMNSmatrix::setTheta12), py::arg("theta_12"))
-        .def("set_theta_13", (&PMNSmatrix::setTheta13), py::arg("theta_13"))
-        .def("set_theta_23", (&PMNSmatrix::setTheta23), py::arg("theta_23"))
-        .def("set_delta_cp", (&PMNSmatrix::setDeltaCP), py::arg("delta_cp"))
-        .def("get_theta_12_tensor", (&PMNSmatrix::getTheta12Tensor), py::return_value_policy::reference)
-        .def("get_theta_13_tensor", (&PMNSmatrix::getTheta13Tensor), py::return_value_policy::reference)
-        .def("get_theta_23_tensor", (&PMNSmatrix::getTheta23Tensor), py::return_value_policy::reference)
-        .def("get_delta_cp_tensor", (&PMNSmatrix::getDeltaCPTensor), py::return_value_policy::reference)
+        .def("set_theta12", (&PMNSmatrix::setTheta12), py::arg("theta_12"))
+        .def("set_theta13", (&PMNSmatrix::setTheta13), py::arg("theta_13"))
+        .def("set_theta23", (&PMNSmatrix::setTheta23), py::arg("theta_23"))
+        .def("set_deltacp", (&PMNSmatrix::setDeltaCP), py::arg("delta_cp"))
+        .def("get_theta12_tensor", (&PMNSmatrix::getTheta12Tensor), py::return_value_policy::reference)
+        .def("get_theta13_tensor", (&PMNSmatrix::getTheta13Tensor), py::return_value_policy::reference)
+        .def("get_theta23_tensor", (&PMNSmatrix::getTheta23Tensor), py::return_value_policy::reference)
+        .def("get_deltacp_tensor", (&PMNSmatrix::getDeltaCPTensor), py::return_value_policy::reference)
         ;
 
 }

--- a/python/binding.cpp
+++ b/python/binding.cpp
@@ -404,8 +404,8 @@ void initPropagator(py::module &m_nuTens)
         ;
 
     py::class_<Propagator>(m_propagator, "Propagator")
-        .def(py::init<int, float, bool>(), 
-            py::arg("n_generations"), py::arg("baseline"), py::arg("anti_neutrino")=false)
+        .def(py::init<int>(), 
+            py::arg("n_generations"))
         .def("calculate_probabilities", &Propagator::calculateProbs,
             "Calculate the oscillation probabilities for neutrinos of specified energies"
         )
@@ -424,14 +424,6 @@ void initPropagator(py::module &m_nuTens)
         .def("set_mixing_matrix", py::overload_cast<Tensor &>(&Propagator::setMixingMatrix),
             "Set the mixing matrix that the propagator should use",
             py::arg("new_matrix")
-        )
-        .def("set_mixing_matrix", py::overload_cast<const std::vector<int> &, float>(&Propagator::setMixingMatrix),
-            "Set a particular value within the mixing matrix used by the propagator",
-            py::arg("indices"), py::arg("value")
-        )
-        .def("set_mixing_matrix", py::overload_cast<const std::vector<int> &, std::complex<float>>(&Propagator::setMixingMatrix),
-            "Set the mixing matrix that the propagator should use",
-            py::arg("indices"), py::arg("value")
         )
         .def("set_baseline", (&Propagator::setBaseline),
             "Set the baseline that the propagator should use",

--- a/python/binding.cpp
+++ b/python/binding.cpp
@@ -487,10 +487,22 @@ void initPropagator(py::module &m_nuTens)
 
      py::class_<ConstDensityMatterSolver, std::shared_ptr<ConstDensityMatterSolver>, BaseMatterSolver>(
         m_propagator, "ConstDensitySolver")
-        .def(py::init<int, float, bool>(), 
-            py::arg("n_generations"), py::arg("density"), py::arg("anti_neutrino")=false)
+        .def(py::init<int>(), 
+            py::arg("n_generations"))
         .def("set_density", (&ConstDensityMatterSolver::setDensity),
             "Set the density that the solver should use",
+            py::arg("new_value")
+        )
+        .def("set_antineutrino", (&ConstDensityMatterSolver::setAntiNeutrino),
+            "Set the density that the solver should use",
+            py::arg("new_value")
+        )
+        .def("set_mixing_matrix", (&ConstDensityMatterSolver::setMixingMatrix),
+            "Set the mixing that the solver should use",
+            py::arg("new_value")
+        )
+        .def("set_masses", (&ConstDensityMatterSolver::setMasses),
+            "Set the neutrino masses that the solver should use",
             py::arg("new_value")
         )
         .def("get_density", (&ConstDensityMatterSolver::getDensity),

--- a/python/binding.cpp
+++ b/python/binding.cpp
@@ -518,8 +518,10 @@ void initPropagator(py::module &m_nuTens)
      py::class_<PMNSmatrix, std::shared_ptr<PMNSmatrix>, BaseMixingMatrix>(
         m_propagator, "PMNSmatrix")
         .def(py::init<>())
-        .def("set_parameter_values", (&PMNSmatrix::setParameterValues),
-            py::arg("theta_12"), py::arg("theta_13"), py::arg("theta_23"), py::arg("delta_cp"))
+        .def("set_theta_12", (&PMNSmatrix::setTheta12), py::arg("theta_12"))
+        .def("set_theta_13", (&PMNSmatrix::setTheta13), py::arg("theta_13"))
+        .def("set_theta_23", (&PMNSmatrix::setTheta23), py::arg("theta_23"))
+        .def("set_delta_cp", (&PMNSmatrix::setDeltaCP), py::arg("delta_cp"))
         .def("get_theta_12_tensor", (&PMNSmatrix::getTheta12Tensor), py::return_value_policy::reference)
         .def("get_theta_13_tensor", (&PMNSmatrix::getTheta13Tensor), py::return_value_policy::reference)
         .def("get_theta_23_tensor", (&PMNSmatrix::getTheta23Tensor), py::return_value_policy::reference)

--- a/python/nuTens/propagator.pyi
+++ b/python/nuTens/propagator.pyi
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import collections.abc
 import nuTens._pyNuTens.tensor
 import typing
 __all__: list[str] = ['BaseMatterSolver', 'BaseMixingMatrix', 'ConstDensitySolver', 'DPpropagator', 'PMNSmatrix', 'Propagator']
@@ -8,19 +7,19 @@ class BaseMatterSolver:
         """
         calculate the eigenvalues of the Hamiltonian
         """
-    def set_antineutrino(self, new_value: bool) -> None:
+    def set_antineutrino(self, new_value: bool) -> BaseMatterSolver:
         """
         Set whether the solver should calculate values for anti-neutrinos
         """
-    def set_energies(self, new_energies: nuTens._pyNuTens.tensor.Tensor) -> None:
+    def set_energies(self, new_energies: nuTens._pyNuTens.tensor.Tensor) -> BaseMatterSolver:
         """
         Set the neutrino energies
         """
-    def set_masses(self, new_masses: nuTens._pyNuTens.tensor.Tensor) -> None:
+    def set_masses(self, new_masses: nuTens._pyNuTens.tensor.Tensor) -> BaseMatterSolver:
         """
         Set the neutrino masses the solver should use
         """
-    def set_mixing_matrix(self, new_matrix: nuTens._pyNuTens.tensor.Tensor) -> None:
+    def set_mixing_matrix(self, new_matrix: nuTens._pyNuTens.tensor.Tensor) -> BaseMatterSolver:
         """
         Set the mixing matrix that the solver should use
         """
@@ -28,15 +27,27 @@ class BaseMixingMatrix:
     def build(self) -> nuTens._pyNuTens.tensor.Tensor:
         ...
 class ConstDensitySolver(BaseMatterSolver):
-    def __init__(self, n_generations: typing.SupportsInt | typing.SupportsIndex, density: typing.SupportsFloat | typing.SupportsIndex, anti_neutrino: bool = False) -> None:
+    def __init__(self, n_generations: typing.SupportsInt | typing.SupportsIndex) -> None:
         ...
     def get_density(self) -> float:
         """
         Get the density used by the solver
         """
-    def set_density(self, new_value: typing.SupportsFloat | typing.SupportsIndex) -> None:
+    def set_antineutrino(self, new_value: bool) -> ConstDensitySolver:
         """
         Set the density that the solver should use
+        """
+    def set_density(self, new_value: typing.SupportsFloat | typing.SupportsIndex) -> ConstDensitySolver:
+        """
+        Set the density that the solver should use
+        """
+    def set_masses(self, new_value: nuTens._pyNuTens.tensor.Tensor) -> ConstDensitySolver:
+        """
+        Set the neutrino masses that the solver should use
+        """
+    def set_mixing_matrix(self, new_value: nuTens._pyNuTens.tensor.Tensor) -> ConstDensitySolver:
+        """
+        Set the mixing that the solver should use
         """
 class DPpropagator(Propagator):
     def __init__(self, NR_iterations: typing.SupportsInt | typing.SupportsIndex) -> None:
@@ -69,7 +80,7 @@ class DPpropagator(Propagator):
         """
         set the density
         """
-    def set_energies(self, new_energies: nuTens._pyNuTens.tensor.Tensor) -> None:
+    def set_energies(self, new_energies: nuTens._pyNuTens.tensor.Tensor) -> DPpropagator:
         """
         set the neutrino energies
         """
@@ -84,18 +95,24 @@ class DPpropagator(Propagator):
 class PMNSmatrix(BaseMixingMatrix):
     def __init__(self) -> None:
         ...
-    def get_delta_cp_tensor(self) -> nuTens._pyNuTens.tensor.Tensor:
+    def get_deltacp_tensor(self) -> nuTens._pyNuTens.tensor.Tensor:
         ...
-    def get_theta_12_tensor(self) -> nuTens._pyNuTens.tensor.Tensor:
+    def get_theta12_tensor(self) -> nuTens._pyNuTens.tensor.Tensor:
         ...
-    def get_theta_13_tensor(self) -> nuTens._pyNuTens.tensor.Tensor:
+    def get_theta13_tensor(self) -> nuTens._pyNuTens.tensor.Tensor:
         ...
-    def get_theta_23_tensor(self) -> nuTens._pyNuTens.tensor.Tensor:
+    def get_theta23_tensor(self) -> nuTens._pyNuTens.tensor.Tensor:
         ...
-    def set_parameter_values(self, theta_12: typing.SupportsFloat | typing.SupportsIndex, theta_13: typing.SupportsFloat | typing.SupportsIndex, theta_23: typing.SupportsFloat | typing.SupportsIndex, delta_cp: typing.SupportsFloat | typing.SupportsIndex) -> None:
+    def set_deltacp(self, delta_cp: typing.SupportsFloat | typing.SupportsIndex) -> PMNSmatrix:
+        ...
+    def set_theta12(self, theta_12: typing.SupportsFloat | typing.SupportsIndex) -> PMNSmatrix:
+        ...
+    def set_theta13(self, theta_13: typing.SupportsFloat | typing.SupportsIndex) -> PMNSmatrix:
+        ...
+    def set_theta23(self, theta_23: typing.SupportsFloat | typing.SupportsIndex) -> PMNSmatrix:
         ...
 class Propagator:
-    def __init__(self, n_generations: typing.SupportsInt | typing.SupportsIndex, baseline: typing.SupportsFloat | typing.SupportsIndex, anti_neutrino: bool = False) -> None:
+    def __init__(self, n_generations: typing.SupportsInt | typing.SupportsIndex) -> None:
         ...
     def calculate_probabilities(self) -> nuTens._pyNuTens.tensor.Tensor:
         """
@@ -105,38 +122,27 @@ class Propagator:
         """
         Get the baseline used by the propagator
         """
-    def set_antineutrino(self, new_value: bool) -> None:
+    def set_antineutrino(self, new_value: bool) -> Propagator:
         """
         Set whether the propagator should calculate oscillations for anti-neutrinos
         """
-    def set_baseline(self, new_value: typing.SupportsFloat | typing.SupportsIndex) -> None:
+    def set_baseline(self, new_value: typing.SupportsFloat | typing.SupportsIndex) -> Propagator:
         """
         Set the baseline that the propagator should use
         """
-    def set_energies(self, new_energies: nuTens._pyNuTens.tensor.Tensor) -> None:
+    def set_energies(self, new_energies: nuTens._pyNuTens.tensor.Tensor) -> Propagator:
         """
         Set the neutrino energies that the propagator should use
         """
-    def set_masses(self, new_masses: nuTens._pyNuTens.tensor.Tensor) -> None:
+    def set_masses(self, new_masses: nuTens._pyNuTens.tensor.Tensor) -> Propagator:
         """
         Set the neutrino mass state eigenvalues
         """
-    def set_matter_solver(self, new_matter_solver: BaseMatterSolver) -> None:
+    def set_matter_solver(self, new_matter_solver: BaseMatterSolver) -> Propagator:
         """
         Set the matter effect solver that the propagator should use
         """
-    @typing.overload
-    def set_mixing_matrix(self, new_matrix: nuTens._pyNuTens.tensor.Tensor) -> None:
-        """
-        Set the mixing matrix that the propagator should use
-        """
-    @typing.overload
-    def set_mixing_matrix(self, indices: collections.abc.Sequence[typing.SupportsInt | typing.SupportsIndex], value: typing.SupportsFloat | typing.SupportsIndex) -> None:
-        """
-        Set a particular value within the mixing matrix used by the propagator
-        """
-    @typing.overload
-    def set_mixing_matrix(self, indices: collections.abc.Sequence[typing.SupportsInt | typing.SupportsIndex], value: typing.SupportsComplex | typing.SupportsFloat | typing.SupportsIndex) -> None:
+    def set_mixing_matrix(self, new_matrix: nuTens._pyNuTens.tensor.Tensor) -> Propagator:
         """
         Set the mixing matrix that the propagator should use
         """

--- a/tests/python/test_three_flavour_oscillations.py
+++ b/tests/python/test_three_flavour_oscillations.py
@@ -32,7 +32,7 @@ class TestTwoFlavourConstMatter:
     def setup_tensor_inputs(self, theta12:float, theta13:float, theta23:float) -> typing.Tuple[Tensor]:
         
         pmns = PMNSmatrix()
-        pmns.set_parameter_values(theta12, theta13, theta23, self.deltaCP)
+        pmns.set_theta12(theta12).set_theta13(theta13).set_theta23(theta23).set_deltacp(self.deltaCP)
 
         masses = Tensor([self.m1, self.m2, self.m3], nt.dtype.scalar_type.complex_float, nt.dtype.device_type.cpu, False).add_batch_dim()
 
@@ -52,8 +52,8 @@ class TestTwoFlavourConstMatter:
         pmns, masses = self.setup_tensor_inputs(theta12, theta13, theta23)
 
         # set up tensor solver
-        propagator = nt.propagator.Propagator(3, self.baseline)
-        matter_solver = ConstDensitySolver(3, self.density)
+        propagator = nt.propagator.Propagator(3).set_baseline(self.baseline)
+        matter_solver = ConstDensitySolver(3).set_density(self.density)
         
         propagator.set_matter_solver(matter_solver)
         propagator.set_mixing_matrix(pmns)

--- a/tests/python/test_two_flavour_oscillations.py
+++ b/tests/python/test_two_flavour_oscillations.py
@@ -44,7 +44,7 @@ class TestTwoFlavourConstMatter:
         pmns, masses = self.setup_tensor_inputs(mass_diff, theta)
 
         # set up tensor solver
-        tensor_solver = ConstDensitySolver(2, self.density)
+        tensor_solver = ConstDensitySolver(2).set_density(self.density)
         tensor_solver.set_mixing_matrix(pmns)
         tensor_solver.set_masses(masses)
         tensor_solver.set_energies(self.energy_tensor)
@@ -92,8 +92,8 @@ class TestTwoFlavourConstMatter:
         pmns, masses = self.setup_tensor_inputs(mass_diff, theta)
 
         # set up tensor solver
-        propagator = nt.propagator.Propagator(2, self.baseline)
-        matter_solver = ConstDensitySolver(2, self.density)
+        propagator = nt.propagator.Propagator(2).set_baseline(self.baseline)
+        matter_solver = ConstDensitySolver(2).set_density(self.density)
         
         propagator.set_matter_solver(matter_solver)
         propagator.set_mixing_matrix(pmns)

--- a/tests/test-DP-propagator.cpp
+++ b/tests/test-DP-propagator.cpp
@@ -44,7 +44,7 @@ class DPpropagatorTest : public gtest::TestWithParam<float>
 
     Tensor energies = Tensor::ones({1, 1}, dtypes::kComplexFloat).requiresGrad(false).hasBatchDim(true);
 
-    Propagator tensorPropagator = Propagator(3, baseline);
+    Propagator tensorPropagator = Propagator(3).setBaseline(baseline);
     std::shared_ptr<ConstDensityMatterSolver> tensorSolver = std::make_shared<ConstDensityMatterSolver>(3);
 
     DPpropagator dpPropagator = DPpropagator(10).setBaseline(baseline).setAntiNeutrino(false).setDensity(density);

--- a/tests/test-DP-propagator.cpp
+++ b/tests/test-DP-propagator.cpp
@@ -45,7 +45,7 @@ class DPpropagatorTest : public gtest::TestWithParam<float>
     Tensor energies = Tensor::ones({1, 1}, dtypes::kComplexFloat).requiresGrad(false).hasBatchDim(true);
 
     Propagator tensorPropagator = Propagator(3, baseline);
-    std::shared_ptr<ConstDensityMatterSolver> tensorSolver = std::make_shared<ConstDensityMatterSolver>(3, density);
+    std::shared_ptr<ConstDensityMatterSolver> tensorSolver = std::make_shared<ConstDensityMatterSolver>(3);
 
     DPpropagator dpPropagator = DPpropagator(10).setBaseline(baseline).setAntiNeutrino(false).setDensity(density);
     DPpropagator dpPropagatorVac = DPpropagator(10).setBaseline(baseline).setAntiNeutrino(false).setDensity(0.0);
@@ -59,6 +59,7 @@ class DPpropagatorTest : public gtest::TestWithParam<float>
     {
 
         energies.setValue({0, 0}, energy);
+        tensorSolver->setDensity(density);
 
         tensorPropagator.setMatterSolver(tensorSolver);
         tensorPropagator.setMasses(masses);

--- a/tests/test-DP-propagator.cpp
+++ b/tests/test-DP-propagator.cpp
@@ -96,8 +96,10 @@ class DPpropagatorTest : public gtest::TestWithParam<float>
         deltaCP.setValue({0}, dcp);
 
         // calculate new values of the mixing matrix
-        pmns.setParameterValues(theta12.getValue<float>({0}), theta13.getValue<float>({0}),
-                                theta23.getValue<float>({0}), deltaCP.getValue<float>({0}));
+        pmns.setTheta12(theta12.getValue<float>({0}))
+            .setTheta13(theta13.getValue<float>({0}))
+            .setTheta23(theta23.getValue<float>({0}))
+            .setDeltaCP(deltaCP.getValue<float>({0}));
     }
 
     /// compare DP propagator oscillation probabilities to the "official" nufast code

--- a/tests/test-pmns-matrix.cpp
+++ b/tests/test-pmns-matrix.cpp
@@ -25,7 +25,7 @@ class PMNSmatrixTest : public gtest::TestWithParam<float>
     // NOLINTEND(cppcoreguidelines-non-private-member-variables-in-classes)
 
     // set up common values to use across tests
-    void SetUp()
+    void SetUp() override
     {
 
         matrix.setTheta12(theta12).setTheta13(theta13).setTheta23(theta23).setDeltaCP(deltaCP);

--- a/tests/test-pmns-matrix.cpp
+++ b/tests/test-pmns-matrix.cpp
@@ -28,7 +28,7 @@ class PMNSmatrixTest : public gtest::TestWithParam<float>
     void SetUp()
     {
 
-        matrix.setParameterValues(theta12, theta13, theta23, deltaCP);
+        matrix.setTheta12(theta12).setTheta13(theta13).setTheta23(theta23).setDeltaCP(deltaCP);
 
         matrixTensor = matrix.build();
     }
@@ -38,7 +38,7 @@ TEST_F(PMNSmatrixTest /*unused*/, CachingSameResultTest /*unused*/)
 {
 
     PMNSmatrix cacheMatrix;
-    cacheMatrix.setParameterValues(theta12, theta13, theta23, deltaCP);
+    cacheMatrix.setTheta12(theta12).setTheta13(theta13).setTheta23(theta23).setDeltaCP(deltaCP);
 
     // copy resulting tensor
     Tensor cachedMatrixTensor = Tensor::zeros({1, 3, 3}, dtypes::kComplexFloat, dtypes::kCPU, false);

--- a/tests/test-three-flavour-osc.cpp
+++ b/tests/test-three-flavour-osc.cpp
@@ -72,7 +72,7 @@ class ThreeFlavourOscillations : public gtest::TestWithParam<float>
 
         // construct the mixing matrix for current theta value
         PMNSmatrix pmns;
-        pmns.setParameterValues(theta12, theta13, theta23, deltaCP);
+        pmns.setTheta12(theta12).setTheta13(theta13).setTheta23(theta23).setDeltaCP(deltaCP);
         Tensor pmnsTensor = pmns.build();
 
         // set up the matter solver
@@ -139,7 +139,7 @@ class ThreeFlavourOscillations : public gtest::TestWithParam<float>
 
         // construct the mixing matrix for current theta value
         PMNSmatrix pmns;
-        pmns.setParameterValues(theta12, theta13, theta23, deltaCP);
+        pmns.setTheta12(theta12).setTheta13(theta13).setTheta23(theta23).setDeltaCP(deltaCP);
         Tensor pmnsTensor = pmns.build();
 
         // set up the matter solver
@@ -234,7 +234,7 @@ class ThreeFlavourOscillations : public gtest::TestWithParam<float>
 
         // construct the mixing matrix for current theta value
         PMNSmatrix pmns;
-        pmns.setParameterValues(theta12, theta13, theta23, deltaCP);
+        pmns.setTheta12(theta12).setTheta13(theta13).setTheta23(theta23).setDeltaCP(deltaCP);
         Tensor pmnsTensor = pmns.build();
 
         NT_INFO("Re[PMNS]:\n{}", pmns.build().real().toString());
@@ -300,7 +300,7 @@ class ThreeFlavourOscillations : public gtest::TestWithParam<float>
 
         // construct the mixing matrix for current theta value
         PMNSmatrix pmns;
-        pmns.setParameterValues(theta12, theta13, theta23, deltaCP);
+        pmns.setTheta12(theta12).setTheta13(theta13).setTheta23(theta23).setDeltaCP(deltaCP);
         Tensor pmnsTensor = pmns.build();
 
         NT_INFO("Re[PMNS]:\n{}", pmns.build().real().toString());

--- a/tests/test-three-flavour-osc.cpp
+++ b/tests/test-three-flavour-osc.cpp
@@ -76,7 +76,7 @@ class ThreeFlavourOscillations : public gtest::TestWithParam<float>
         Tensor pmnsTensor = pmns.build();
 
         // set up the matter solver
-        Propagator tensorPropagator(3, baseline);
+        Propagator tensorPropagator = Propagator(3).setBaseline(baseline);
         auto tensorSolver = std::make_shared<ConstDensityMatterSolver>(3);
         tensorSolver->setDensity(density);
 
@@ -143,7 +143,7 @@ class ThreeFlavourOscillations : public gtest::TestWithParam<float>
         Tensor pmnsTensor = pmns.build();
 
         // set up the matter solver
-        Propagator tensorPropagator(3, baseline);
+        Propagator tensorPropagator = Propagator(3).setBaseline(baseline);
         auto tensorSolver = std::make_shared<ConstDensityMatterSolver>(3);
         tensorSolver->setDensity(density);
 
@@ -241,7 +241,7 @@ class ThreeFlavourOscillations : public gtest::TestWithParam<float>
         NT_INFO("Im[PMNS]:\n{}", pmns.build().imag().toString());
 
         // set up the matter solver
-        Propagator tensorPropagator(3, baseline);
+        Propagator tensorPropagator = Propagator(3).setBaseline(baseline);
         auto tensorSolver = std::make_shared<ConstDensityMatterSolver>(3);
         tensorSolver->setDensity(density);
 
@@ -307,7 +307,7 @@ class ThreeFlavourOscillations : public gtest::TestWithParam<float>
         NT_INFO("Im[PMNS]:\n{}", pmns.build().imag().toString());
 
         // set up the matter solver
-        Propagator tensorPropagator(3, baseline);
+        Propagator tensorPropagator = Propagator(3).setBaseline(baseline);
 
         // set up the propagator
         tensorPropagator.setMixingMatrix(pmns.build());

--- a/tests/test-three-flavour-osc.cpp
+++ b/tests/test-three-flavour-osc.cpp
@@ -77,7 +77,8 @@ class ThreeFlavourOscillations : public gtest::TestWithParam<float>
 
         // set up the matter solver
         Propagator tensorPropagator(3, baseline);
-        auto tensorSolver = std::make_shared<ConstDensityMatterSolver>(3, density);
+        auto tensorSolver = std::make_shared<ConstDensityMatterSolver>(3);
+        tensorSolver->setDensity(density);
 
         // set up the propagator
         tensorPropagator.setMatterSolver(tensorSolver);
@@ -143,7 +144,8 @@ class ThreeFlavourOscillations : public gtest::TestWithParam<float>
 
         // set up the matter solver
         Propagator tensorPropagator(3, baseline);
-        auto tensorSolver = std::make_shared<ConstDensityMatterSolver>(3, density);
+        auto tensorSolver = std::make_shared<ConstDensityMatterSolver>(3);
+        tensorSolver->setDensity(density);
 
         // set up the propagator
         tensorPropagator.setMatterSolver(tensorSolver);
@@ -240,7 +242,8 @@ class ThreeFlavourOscillations : public gtest::TestWithParam<float>
 
         // set up the matter solver
         Propagator tensorPropagator(3, baseline);
-        auto tensorSolver = std::make_shared<ConstDensityMatterSolver>(3, density);
+        auto tensorSolver = std::make_shared<ConstDensityMatterSolver>(3);
+        tensorSolver->setDensity(density);
 
         // set up the propagator
         tensorPropagator.setMatterSolver(tensorSolver);

--- a/tests/test-two-flavour-osc.cpp
+++ b/tests/test-two-flavour-osc.cpp
@@ -49,7 +49,7 @@ class TwoFlavourOscillations : public gtest::TestWithParam<float>
 
         std::cout << "\n#### const density test for theta = " << theta << " ####" << std::endl;
 
-        Propagator tensorPropagator(2, baseline);
+        Propagator tensorPropagator = Propagator(2).setBaseline(baseline);
         auto tensorSolver = std::make_shared<ConstDensityMatterSolver>(2);
         tensorSolver->setDensity(density);
 
@@ -138,7 +138,7 @@ TEST_P(TwoFlavourOscillations /*unused*/, VacuumOscProbs /*unused*/)
 
     std::cout << "\n#### vacuum test for theta = " << theta << " ####" << std::endl;
 
-    Propagator tensorPropagator(2, baseline);
+    Propagator tensorPropagator = Propagator(2).setBaseline(baseline);
     tensorPropagator.setMasses(masses);
 
     // will use this for baseline for comparisons

--- a/tests/test-two-flavour-osc.cpp
+++ b/tests/test-two-flavour-osc.cpp
@@ -50,7 +50,8 @@ class TwoFlavourOscillations : public gtest::TestWithParam<float>
         std::cout << "\n#### const density test for theta = " << theta << " ####" << std::endl;
 
         Propagator tensorPropagator(2, baseline);
-        auto tensorSolver = std::make_shared<ConstDensityMatterSolver>(2, density);
+        auto tensorSolver = std::make_shared<ConstDensityMatterSolver>(2);
+        tensorSolver->setDensity(density);
 
         // linter seems to struggle with recogising this type and thinks it is an int
         // and always thinks it is uninitialised


### PR DESCRIPTION
Now use setters instead of constructor arguments for remaining propagator classes - to avoid accidentally setting wrong parameters / make things more readable